### PR TITLE
chore: upgrade Java baseline from 17 to 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ permissions:
   contents: write
 
 env:
-  JAVA_VERSION: '17'
+  JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: ['17', '21', '25']
+        java-version: ['21', '25']
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ flowchart TB
 
 | Component | Version |
 |-----------|---------|
-| Java | 17+ |
+| Java | 21+ |
 | Spring Boot | 4.0+ |
 
 ## Installation

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -4,7 +4,7 @@ This guide explains how to add HTTP access logging to your Spring Boot applicati
 
 ## Prerequisites
 
-- Java 17 or later
+- Java 21 or later
 - Spring Boot 4.0 or later
 - Tomcat or Jetty embedded server
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ Start your application and access logs will appear in the console.
 
 | Component | Version |
 |-----------|---------|
-| Java | 17+ |
+| Java | 21+ |
 | Spring Boot | 4.0+ |
 | Kotlin | 2.0+ (if using Kotlin) |
 

--- a/docs/ja/guide/getting-started.md
+++ b/docs/ja/guide/getting-started.md
@@ -4,7 +4,7 @@
 
 ## 前提条件
 
-- Java 17以上
+- Java 21以上
 - Spring Boot 4.0以上
 - TomcatまたはJetty組み込みサーバー
 

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -107,7 +107,7 @@ implementation 'io.github.seijikohara:logback-access-spring-boot-starter:1.0.0'
 
 | コンポーネント | バージョン |
 |---------------|-----------|
-| Java | 17以上 |
+| Java | 21以上 |
 | Spring Boot | 4.0以上 |
 | Kotlin | 2.0以上（Kotlin使用時） |
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -141,7 +141,7 @@ classDiagram
 
 | Component | Version |
 |-----------|---------|
-| Java | 17+ |
+| Java | 21+ |
 | Gradle | 8.x |
 
 ## Running Tests

--- a/examples/common/build.gradle.kts
+++ b/examples/common/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/examples/jetty-mvc/build.gradle.kts
+++ b/examples/jetty-mvc/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/examples/jetty-webflux/build.gradle.kts
+++ b/examples/jetty-webflux/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/examples/tomcat-mvc/build.gradle.kts
+++ b/examples/tomcat-mvc/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/examples/tomcat-webflux/build.gradle.kts
+++ b/examples/tomcat-webflux/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,19 @@
 [versions]
 axion-release = "1.21.1"
-error-prone = "2.41.0"
+error-prone = "2.47.0"
 jspecify = "1.0.0"
-kotest = "6.1.2"
+kotest = "6.1.3"
 kotlin-logging = "7.0.14"
 logback-access = "2.0.9"
-logstash-logback-encoder = "8.0"
+logstash-logback-encoder = "9.0"
 maven-publish = "0.36.0"
-mockk = "1.14.2"
-nullaway = "0.12.6"
+mockk = "1.14.9"
+nullaway = "0.13.1"
 spring-boot = "4.0.2"
 
 [libraries]
 error-prone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "error-prone" }
 jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
-nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core" }
 kotest-bom = { module = "io.kotest:kotest-bom", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5" }
@@ -23,6 +22,7 @@ kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
 logback-access-common = { module = "ch.qos.logback.access:logback-access-common", version.ref = "logback-access" }
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstash-logback-encoder" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
 spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter" }
 spring-boot-starter-jetty = { module = "org.springframework.boot:spring-boot-starter-jetty" }
@@ -36,8 +36,8 @@ spring-boot-starter-webmvc = { module = "org.springframework.boot:spring-boot-st
 axion-release = { id = "pl.allegro.tech.build.axion-release", version.ref = "axion-release" }
 detekt = "dev.detekt:2.0.0-alpha.2"
 dokka = "org.jetbrains.dokka:2.1.0"
-errorprone = "net.ltgt.errorprone:4.2.0"
-kotlin-jvm = "org.jetbrains.kotlin.jvm:2.3.0"
+errorprone = "net.ltgt.errorprone:5.0.0"
+kotlin-jvm = "org.jetbrains.kotlin.jvm:2.3.10"
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }
 nullaway = "net.ltgt.nullaway:3.0.0"
 spotless = "com.diffplug.spotless:8.2.1"

--- a/logback-access-spring-boot-starter/build.gradle.kts
+++ b/logback-access-spring-boot-starter/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 


### PR DESCRIPTION
## Summary
- Upgrade Java baseline from 17 to 21
- Update dependencies requiring Java 21
- Update CI matrix to test Java 21 and 25 only
- Update documentation to reflect new requirements

## Changes

### Build Configuration (6 files)
- `logback-access-spring-boot-starter/build.gradle.kts`: Java 17 → 21
- `examples/common/build.gradle.kts`: Java 17 → 21
- `examples/tomcat-mvc/build.gradle.kts`: Java 17 → 21
- `examples/jetty-mvc/build.gradle.kts`: Java 17 → 21
- `examples/tomcat-webflux/build.gradle.kts`: Java 17 → 21
- `examples/jetty-webflux/build.gradle.kts`: Java 17 → 21

### Dependencies (gradle/libs.versions.toml)
| Dependency | Old | New |
|------------|-----|-----|
| error-prone | 2.41.0 | 2.47.0 |
| kotest | 6.1.2 | 6.1.3 |
| logstash-logback-encoder | 8.0 | 9.0 |
| mockk | 1.14.2 | 1.14.9 |
| nullaway | 0.12.6 | 0.13.1 |
| errorprone plugin | 4.2.0 | 5.0.0 |
| kotlin-jvm | 2.3.0 | 2.3.10 |

### GitHub Actions (2 files)
- `.github/workflows/test.yml`: Remove Java 17 from test matrix
- `.github/workflows/release.yml`: Use Java 21 for releases

### Documentation (6 files)
- `README.md`: Java 17+ → 21+
- `examples/README.md`: Java 17+ → 21+
- `docs/index.md`: Java 17+ → 21+
- `docs/guide/getting-started.md`: Java 17 → 21
- `docs/ja/index.md`: Java 17以上 → 21以上
- `docs/ja/guide/getting-started.md`: Java 17以上 → 21以上

## Test plan
- [x] `./gradlew clean build` passes locally
- [ ] CI passes on Java 21 and 25