### PR TITLE
chore: add GitHub dependency graph submission workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,27 @@
+name: Dependency Submission
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Submit dependency graph
+        uses: gradle/actions/dependency-submission@v4


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependency-submission.yml` to submit Gradle dependency graph to GitHub
- Triggers on push to `main` only
- Uses `gradle/actions/dependency-submission@v4` for accurate transitive dependency resolution
- Enhances Dependabot alerts with full dependency tree visibility

Closes #14