### PR TITLE
feat: enable Kotlin explicit API mode on core module

### DIFF
--- a/logback-access-spring-boot-starter-core/build.gradle.kts
+++ b/logback-access-spring-boot-starter-core/build.gradle.kts
@@ -23,6 +23,10 @@ dependencies {
     implementation(libs.kotlin.logging)
 }
 
+kotlin {
+    explicitApi()
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/AccessEventData.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/AccessEventData.kt
@@ -9,7 +9,7 @@ import java.io.Serializable
  * deferred processing and serialization without holding references to
  * server-specific request/response objects.
  */
-data class AccessEventData(
+public data class AccessEventData(
     /** Timestamp when the request was received (epoch milliseconds). */
     val timeStamp: Long,
     /** Time elapsed processing the request in milliseconds, or null if unavailable. */
@@ -68,11 +68,11 @@ data class AccessEventData(
         requestParameterMap.mapValues { (_, values) -> values.toTypedArray() }
     }
 
-    companion object {
+    public companion object {
         private const val serialVersionUID: Long = 1L
 
         /** Request attribute key for the remote user set by the security filter. */
-        const val REMOTE_USER_ATTR: String =
+        public const val REMOTE_USER_ATTR: String =
             "io.github.seijikohara.spring.boot.logback.access.remoteUser"
     }
 }

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LocalPortStrategy.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LocalPortStrategy.kt
@@ -3,7 +3,7 @@ package io.github.seijikohara.spring.boot.logback.access
 /**
  * Strategy for resolving the local port reported in access log events.
  */
-enum class LocalPortStrategy {
+public enum class LocalPortStrategy {
     /**
      * Returns the port number of the interface on which the request was received.
      */

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContext.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContext.kt
@@ -18,14 +18,14 @@ import org.springframework.util.ResourceUtils.getURL
  * with Spring environment support, and provides the [emit] entry point
  * for server integrations.
  */
-class LogbackAccessContext(
+public class LogbackAccessContext(
     /** Configuration properties for this context. */
-    val properties: LogbackAccessProperties,
+    public val properties: LogbackAccessProperties,
     resourceLoader: ResourceLoader,
     environment: Environment,
 ) : AutoCloseable {
     /** The underlying Logback-access context. */
-    val accessContext: AccessContext = AccessContext()
+    public val accessContext: AccessContext = AccessContext()
 
     init {
         val (name, resource) = resolveConfig(properties, resourceLoader)
@@ -51,7 +51,7 @@ class LogbackAccessContext(
      * Exceptions from appenders are caught and logged to prevent
      * application crashes due to logging failures.
      */
-    fun emit(event: LogbackAccessEvent) {
+    public fun emit(event: LogbackAccessEvent) {
         runCatching {
             event
                 .takeIf { shouldLog(it.requestURI) }
@@ -90,7 +90,7 @@ class LogbackAccessContext(
 
     override fun toString(): String = "LogbackAccessContext(${accessContext.name})"
 
-    companion object {
+    private companion object {
         private val logger = KotlinLogging.logger {}
 
         private fun resolveConfig(

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessEvent.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessEvent.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
  * Since all data is captured eagerly in [AccessEventData],
  * [prepareForDeferredProcessing] is a no-op and serialization works naturally.
  */
-class LogbackAccessEvent
+public class LogbackAccessEvent
     @JvmOverloads
     constructor(
         private val data: AccessEventData,
@@ -101,7 +101,7 @@ class LogbackAccessEvent
 
         override fun toString(): String = "${this::class.simpleName}(${data.requestURL} ${data.statusCode})"
 
-        companion object {
+        private companion object {
             private const val serialVersionUID: Long = 1L
 
             /** Reusable empty parameter array to avoid repeated allocation. */

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties.kt
@@ -17,7 +17,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue
  * @property filter URL filtering properties.
  */
 @ConfigurationProperties("logback.access")
-data class LogbackAccessProperties
+public data class LogbackAccessProperties
     @ConstructorBinding
     constructor(
         @DefaultValue("true")
@@ -38,7 +38,7 @@ data class LogbackAccessProperties
          * @property requestAttributesEnabled Whether to enable request attributes for use with RemoteIpValve.
          *           Defaults to the presence of RemoteIpValve when not specified.
          */
-        data class TomcatProperties(
+        public data class TomcatProperties(
             val requestAttributesEnabled: Boolean?,
         )
 
@@ -49,7 +49,7 @@ data class LogbackAccessProperties
          * @property includeHosts Comma-separated host names to activate. All hosts when not specified.
          * @property excludeHosts Comma-separated host names to deactivate.
          */
-        data class TeeFilterProperties
+        public data class TeeFilterProperties
             @ConstructorBinding
             constructor(
                 @DefaultValue("false")
@@ -65,15 +65,15 @@ data class LogbackAccessProperties
          *           All URLs when not specified.
          * @property excludeUrlPatterns Regex patterns for URLs to exclude from access logging.
          */
-        data class FilterProperties(
+        public data class FilterProperties(
             val includeUrlPatterns: List<String>?,
             val excludeUrlPatterns: List<String>?,
         )
 
-        companion object {
+        public companion object {
             /** Default configuration file locations searched in order. */
             @JvmField
-            val DEFAULT_CONFIGS: List<String> =
+            public val DEFAULT_CONFIGS: List<String> =
                 listOf(
                     "classpath:logback-access-test.xml",
                     "classpath:logback-access.xml",
@@ -82,7 +82,7 @@ data class LogbackAccessProperties
                 )
 
             /** Built-in fallback configuration file location. */
-            const val FALLBACK_CONFIG: String =
+            public const val FALLBACK_CONFIG: String =
                 "classpath:io/github/seijikohara/spring/boot/logback/access/logback-access-spring.xml"
         }
     }

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/joran/AccessJoranConfigurator.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/joran/AccessJoranConfigurator.kt
@@ -15,7 +15,7 @@ import java.util.function.Supplier
  *
  * @see org.springframework.boot.logging.logback.SpringBootJoranConfigurator
  */
-class AccessJoranConfigurator(
+public class AccessJoranConfigurator(
     private val environment: Environment,
 ) : JoranConfigurator() {
     override fun addElementSelectorAndActionAssociations(store: RuleStore): Unit =


### PR DESCRIPTION
## Summary
- Enable `kotlin { explicitApi() }` on the core module only (public API contract)
- Add explicit `public` visibility modifiers to all public declarations
- Mark private companion objects as `private` explicitly
- Starter module and examples are excluded (internal implementation)

## Changed Files
- `logback-access-spring-boot-starter-core/build.gradle.kts` — add `explicitApi()`
- 6 Kotlin source files in core module — add `public`/`private` modifiers

Closes #15