### PR TITLE
feat: add binary compatibility validator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,10 +4,22 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
     alias(libs.plugins.axion.release)
+    alias(libs.plugins.binary.compatibility.validator)
     alias(libs.plugins.dokka) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.maven.publish) apply false
     alias(libs.plugins.version.catalog.update)
+}
+
+apiValidation {
+    ignoredProjects += listOf(
+        "logback-access-spring-boot-starter",
+        "common",
+        "tomcat-mvc",
+        "jetty-mvc",
+        "tomcat-webflux",
+        "jetty-webflux",
+    )
 }
 
 group = "io.github.seijikohara"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ spring-boot-starter-webmvc = { module = "org.springframework.boot:spring-boot-st
 
 [plugins]
 axion-release = { id = "pl.allegro.tech.build.axion-release", version.ref = "axion-release" }
+binary-compatibility-validator = "org.jetbrains.kotlinx.binary-compatibility-validator:0.18.1"
 detekt = "dev.detekt:2.0.0-alpha.2"
 dokka = "org.jetbrains.dokka:2.1.0"
 errorprone = "net.ltgt.errorprone:5.0.0"

--- a/logback-access-spring-boot-starter-core/api/logback-access-spring-boot-starter-core.api
+++ b/logback-access-spring-boot-starter-core/api/logback-access-spring-boot-starter-core.api
@@ -1,0 +1,195 @@
+public final class io/github/seijikohara/spring/boot/logback/access/AccessEventData : java/io/Serializable {
+	public static final field Companion Lio/github/seijikohara/spring/boot/logback/access/AccessEventData$Companion;
+	public static final field REMOTE_USER_ATTR Ljava/lang/String;
+	public fun <init> (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;JLjava/lang/String;)V
+	public final fun component1 ()J
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/util/Map;
+	public final fun component16 ()Ljava/util/Map;
+	public final fun component17 ()Ljava/util/Map;
+	public final fun component18 ()Ljava/util/Map;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Long;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()I
+	public final fun component22 ()Ljava/util/Map;
+	public final fun component23 ()J
+	public final fun component24 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()I
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;JLjava/lang/String;)Lio/github/seijikohara/spring/boot/logback/access/AccessEventData;
+	public static synthetic fun copy$default (Lio/github/seijikohara/spring/boot/logback/access/AccessEventData;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ILjava/util/Map;JLjava/lang/String;ILjava/lang/Object;)Lio/github/seijikohara/spring/boot/logback/access/AccessEventData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttributeMap ()Ljava/util/Map;
+	public final fun getContentLength ()J
+	public final fun getCookieMap ()Ljava/util/Map;
+	public final fun getElapsedTime ()Ljava/lang/Long;
+	public final fun getLocalPort ()I
+	public final fun getMethod ()Ljava/lang/String;
+	public final fun getProtocol ()Ljava/lang/String;
+	public final fun getQueryString ()Ljava/lang/String;
+	public final fun getRemoteAddr ()Ljava/lang/String;
+	public final fun getRemoteHost ()Ljava/lang/String;
+	public final fun getRemoteUser ()Ljava/lang/String;
+	public final fun getRequestContent ()Ljava/lang/String;
+	public final fun getRequestHeaderMap ()Ljava/util/Map;
+	public final fun getRequestParameterArrayMap ()Ljava/util/Map;
+	public final fun getRequestParameterMap ()Ljava/util/Map;
+	public final fun getRequestURI ()Ljava/lang/String;
+	public final fun getRequestURL ()Ljava/lang/String;
+	public final fun getResponseContent ()Ljava/lang/String;
+	public final fun getResponseHeaderMap ()Ljava/util/Map;
+	public final fun getSequenceNumber ()Ljava/lang/Long;
+	public final fun getServerName ()Ljava/lang/String;
+	public final fun getSessionID ()Ljava/lang/String;
+	public final fun getStatusCode ()I
+	public final fun getThreadName ()Ljava/lang/String;
+	public final fun getTimeStamp ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/AccessEventData$Companion {
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/LocalPortStrategy : java/lang/Enum {
+	public static final field LOCAL Lio/github/seijikohara/spring/boot/logback/access/LocalPortStrategy;
+	public static final field SERVER Lio/github/seijikohara/spring/boot/logback/access/LocalPortStrategy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/github/seijikohara/spring/boot/logback/access/LocalPortStrategy;
+	public static fun values ()[Lio/github/seijikohara/spring/boot/logback/access/LocalPortStrategy;
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/LogbackAccessContext : java/lang/AutoCloseable {
+	public fun <init> (Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties;Lorg/springframework/core/io/ResourceLoader;Lorg/springframework/core/env/Environment;)V
+	public fun close ()V
+	public final fun emit (Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessEvent;)V
+	public final fun getAccessContext ()Lch/qos/logback/access/common/spi/AccessContext;
+	public final fun getProperties ()Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/LogbackAccessEvent : ch/qos/logback/access/common/spi/IAccessEvent, java/io/Serializable {
+	public fun <init> (Lio/github/seijikohara/spring/boot/logback/access/AccessEventData;)V
+	public fun <init> (Lio/github/seijikohara/spring/boot/logback/access/AccessEventData;Ljakarta/servlet/http/HttpServletRequest;)V
+	public fun <init> (Lio/github/seijikohara/spring/boot/logback/access/AccessEventData;Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;)V
+	public synthetic fun <init> (Lio/github/seijikohara/spring/boot/logback/access/AccessEventData;Ljakarta/servlet/http/HttpServletRequest;Ljakarta/servlet/http/HttpServletResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getAttribute (Ljava/lang/String;)Ljava/lang/String;
+	public fun getContentLength ()J
+	public fun getCookie (Ljava/lang/String;)Ljava/lang/String;
+	public fun getElapsedSeconds ()J
+	public fun getElapsedTime ()J
+	public fun getLocalPort ()I
+	public fun getMethod ()Ljava/lang/String;
+	public fun getProtocol ()Ljava/lang/String;
+	public fun getQueryString ()Ljava/lang/String;
+	public fun getRemoteAddr ()Ljava/lang/String;
+	public fun getRemoteHost ()Ljava/lang/String;
+	public fun getRemoteUser ()Ljava/lang/String;
+	public fun getRequest ()Ljakarta/servlet/http/HttpServletRequest;
+	public fun getRequestContent ()Ljava/lang/String;
+	public fun getRequestHeader (Ljava/lang/String;)Ljava/lang/String;
+	public fun getRequestHeaderMap ()Ljava/util/Map;
+	public fun getRequestHeaderNames ()Ljava/util/Enumeration;
+	public fun getRequestParameter (Ljava/lang/String;)[Ljava/lang/String;
+	public fun getRequestParameterMap ()Ljava/util/Map;
+	public fun getRequestURI ()Ljava/lang/String;
+	public fun getRequestURL ()Ljava/lang/String;
+	public fun getResponse ()Ljakarta/servlet/http/HttpServletResponse;
+	public fun getResponseContent ()Ljava/lang/String;
+	public fun getResponseHeader (Ljava/lang/String;)Ljava/lang/String;
+	public fun getResponseHeaderMap ()Ljava/util/Map;
+	public fun getResponseHeaderNameList ()Ljava/util/List;
+	public fun getSequenceNumber ()J
+	public fun getServerAdapter ()Lch/qos/logback/access/common/spi/ServerAdapter;
+	public fun getServerName ()Ljava/lang/String;
+	public fun getSessionID ()Ljava/lang/String;
+	public fun getStatusCode ()I
+	public fun getThreadName ()Ljava/lang/String;
+	public fun getTimeStamp ()J
+	public fun prepareForDeferredProcessing ()V
+	public fun setThreadName (Ljava/lang/String;)V
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties {
+	public static final field Companion Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$Companion;
+	public static final field DEFAULT_CONFIGS Ljava/util/List;
+	public static final field FALLBACK_CONFIG Ljava/lang/String;
+	public fun <init> (ZLjava/lang/String;Lio/github/seijikohara/spring/boot/logback/access/LocalPortStrategy;Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TomcatProperties;Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$FilterProperties;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/github/seijikohara/spring/boot/logback/access/LocalPortStrategy;
+	public final fun component4 ()Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TomcatProperties;
+	public final fun component5 ()Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;
+	public final fun component6 ()Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$FilterProperties;
+	public final fun copy (ZLjava/lang/String;Lio/github/seijikohara/spring/boot/logback/access/LocalPortStrategy;Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TomcatProperties;Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$FilterProperties;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties;
+	public static synthetic fun copy$default (Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties;ZLjava/lang/String;Lio/github/seijikohara/spring/boot/logback/access/LocalPortStrategy;Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TomcatProperties;Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$FilterProperties;ILjava/lang/Object;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfigLocation ()Ljava/lang/String;
+	public final fun getEnabled ()Z
+	public final fun getFilter ()Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$FilterProperties;
+	public final fun getLocalPortStrategy ()Lio/github/seijikohara/spring/boot/logback/access/LocalPortStrategy;
+	public final fun getTeeFilter ()Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;
+	public final fun getTomcat ()Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TomcatProperties;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$Companion {
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$FilterProperties {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$FilterProperties;
+	public static synthetic fun copy$default (Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$FilterProperties;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$FilterProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getExcludeUrlPatterns ()Ljava/util/List;
+	public final fun getIncludeUrlPatterns ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties {
+	public fun <init> (ZLjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/String;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;
+	public static synthetic fun copy$default (Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Z
+	public final fun getExcludeHosts ()Ljava/lang/String;
+	public final fun getIncludeHosts ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TomcatProperties {
+	public fun <init> (Ljava/lang/Boolean;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TomcatProperties;
+	public static synthetic fun copy$default (Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TomcatProperties;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TomcatProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRequestAttributesEnabled ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/joran/AccessJoranConfigurator : ch/qos/logback/access/common/joran/JoranConfigurator {
+	public fun <init> (Lorg/springframework/core/env/Environment;)V
+	public fun addElementSelectorAndActionAssociations (Lch/qos/logback/core/joran/spi/RuleStore;)V
+	public fun buildModelInterpretationContext ()V
+}
+


### PR DESCRIPTION
## Summary
- Add `kotlinx.binary-compatibility-validator` plugin (v0.18.1) to detect accidental API breaks
- Generate initial API dump for core module (`logback-access-spring-boot-starter-core.api`)
- Exclude non-API modules: starter, examples
- `apiCheck` runs automatically as part of `check` lifecycle in CI

Closes #16