### PR TITLE
chore: configure reproducible builds for all archive tasks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,14 @@ allprojects {
     version = rootProject.version
 }
 
+// Configure reproducible builds for all archive tasks
+subprojects {
+    tasks.withType<AbstractArchiveTask>().configureEach {
+        isPreserveFileTimestamps = false
+        isReproducibleFileOrder = true
+    }
+}
+
 // Common maven-publish configuration for all publishable subprojects
 subprojects {
     pluginManager.withPlugin("com.vanniktech.maven.publish") {


### PR DESCRIPTION
## Summary
- Configure all `AbstractArchiveTask` instances (JAR, ZIP) across subprojects for reproducible output
- Disable file timestamps (`isPreserveFileTimestamps = false`) and enforce reproducible file ordering (`isReproducibleFileOrder = true`)
- Improves supply chain security by ensuring identical inputs produce identical artifacts

Closes #17