### PR TITLE
feat: add CycloneDX SBOM generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,9 @@ jobs:
       - name: Build with release version
         run: ./gradlew clean build
 
+      - name: Generate SBOM
+        run: ./gradlew cyclonedxBom
+
       - name: Publish to Maven Central
         run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
         env:
@@ -253,6 +256,7 @@ jobs:
           draft: false
           prerelease: false
           token: ${{ steps.generate_token.outputs.token }}
+          files: build/reports/cyclonedx/bom.json
 
       - name: Release summary
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 plugins {
     alias(libs.plugins.axion.release)
     alias(libs.plugins.binary.compatibility.validator)
+    alias(libs.plugins.cyclonedx)
     alias(libs.plugins.dokka) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.maven.publish) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ spring-boot-starter-webmvc = { module = "org.springframework.boot:spring-boot-st
 [plugins]
 axion-release = { id = "pl.allegro.tech.build.axion-release", version.ref = "axion-release" }
 binary-compatibility-validator = "org.jetbrains.kotlinx.binary-compatibility-validator:0.18.1"
+cyclonedx = "org.cyclonedx.bom:3.1.0"
 detekt = "dev.detekt:2.0.0-alpha.2"
 dokka = "org.jetbrains.dokka:2.1.0"
 errorprone = "net.ltgt.errorprone:5.0.0"


### PR DESCRIPTION
## Summary
- Add CycloneDX Gradle plugin (3.1.0) to generate Software Bill of Materials in CycloneDX JSON format
- Integrate SBOM generation into the release workflow (`./gradlew cyclonedxBom`)
- Attach generated SBOM (`build/reports/cyclonedx/bom.json`) to GitHub Releases

Closes #18