### PR TITLE
feat: add SLSA build provenance attestation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 env:
   JAVA_VERSION: '21'
@@ -241,6 +243,13 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            logback-access-spring-boot-starter-core/build/libs/*.jar
+            logback-access-spring-boot-starter/build/libs/*.jar
 
       - name: Push tag
         env:


### PR DESCRIPTION
## Summary
- Add `actions/attest-build-provenance@v2` to the release workflow for Sigstore keyless signing
- Add required permissions: `id-token: write` (OIDC) and `attestations: write`
- Attest both core and starter JAR artifacts after Maven Central publish
- Consumers can verify with `gh attestation verify <artifact.jar> --owner seijikohara`

Closes #20