### PR TITLE
feat: add AutoConfiguration backward compatibility layer

### DIFF
--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessAutoConfiguration.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessAutoConfiguration.kt
@@ -1,0 +1,19 @@
+package io.github.seijikohara.spring.boot.logback.access
+
+/**
+ * Deprecated type alias for backward compatibility.
+ *
+ * Use [io.github.seijikohara.spring.boot.logback.access.autoconfigure.LogbackAccessAutoConfiguration] instead.
+ * This alias will be removed in v2.0.0.
+ */
+@Deprecated(
+    message = "Moved to io.github.seijikohara.spring.boot.logback.access.autoconfigure package",
+    replaceWith =
+        ReplaceWith(
+            "LogbackAccessAutoConfiguration",
+            "io.github.seijikohara.spring.boot.logback.access.autoconfigure.LogbackAccessAutoConfiguration",
+        ),
+    level = DeprecationLevel.WARNING,
+)
+typealias LogbackAccessAutoConfiguration =
+    io.github.seijikohara.spring.boot.logback.access.autoconfigure.LogbackAccessAutoConfiguration

--- a/logback-access-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.replacements
+++ b/logback-access-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.replacements
@@ -1,0 +1,1 @@
+io.github.seijikohara.spring.boot.logback.access.LogbackAccessAutoConfiguration=io.github.seijikohara.spring.boot.logback.access.autoconfigure.LogbackAccessAutoConfiguration


### PR DESCRIPTION
## Summary

- Add `AutoConfiguration.replacements` file mapping the old FQN (`...access.LogbackAccessAutoConfiguration`) to the new FQN (`...access.autoconfigure.LogbackAccessAutoConfiguration`) for string-based references (`excludeName`, `spring.autoconfigure.exclude`)
- Add deprecated `typealias` at the old package location to preserve compile-time compatibility for `exclude = [LogbackAccessAutoConfiguration::class]` usage
- The old FQN will be removed in v2.0.0

## Context

The module split (PR #7) moved `LogbackAccessAutoConfiguration` from `...access` to `...access.autoconfigure`. This is technically a breaking change for users who reference the old FQN in:
- `@SpringBootApplication(exclude = [LogbackAccessAutoConfiguration::class])`
- `spring.autoconfigure.exclude` property
- `@AutoConfiguration(before/after)` ordering

This compatibility layer ensures a seamless upgrade path, enabling a **v1.1.0** release instead of v2.0.0.

## Test plan

- [x] `./gradlew clean build` — all tests pass (compile + spotless + detekt + tests)
- [x] `./gradlew apiCheck` — binary compatibility check passes
- [ ] CI passes