### PR TITLE
fix: resolve BOM-managed dependency versions in published POMs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import com.vanniktech.maven.publish.JavaLibrary
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
+import org.gradle.api.publish.maven.MavenPublication
 
 plugins {
     alias(libs.plugins.axion.release)
@@ -65,6 +66,19 @@ subprojects {
 // Common maven-publish configuration for all publishable subprojects
 subprojects {
     pluginManager.withPlugin("com.vanniktech.maven.publish") {
+        // Resolve BOM-managed dependency versions in the generated POM
+        pluginManager.withPlugin("maven-publish") {
+            extensions.configure<PublishingExtension> {
+                publications.withType<MavenPublication>().configureEach {
+                    versionMapping {
+                        allVariants {
+                            fromResolutionResult()
+                        }
+                    }
+                }
+            }
+        }
+
         extensions.configure<MavenPublishBaseExtension> {
             publishToMavenCentral()
             signAllPublications()

--- a/logback-access-spring-boot-starter/build.gradle.kts
+++ b/logback-access-spring-boot-starter/build.gradle.kts
@@ -16,6 +16,7 @@ mavenPublishing {
 
 dependencies {
     api(project(":logback-access-spring-boot-starter-core"))
+    api(platform(libs.spring.boot.dependencies))
 
     implementation(libs.spring.boot.starter)
     implementation(libs.kotlin.logging)


### PR DESCRIPTION
## Summary

- Add `api(platform(libs.spring.boot.dependencies))` to the starter module so the BOM is declared in its POM
- Add `versionMapping { allVariants { fromResolutionResult() } }` to resolve BOM-managed dependency versions into explicit version numbers in all published POMs

## Context

The v1.1.0 release workflow failed at the Maven Central validation step with:
```
Dependency version information is missing for dependency: org.springframework.boot:spring-boot-starter
```

Maven Central requires all `<dependency>` entries in the POM to have explicit `<version>` elements. The Spring Boot BOM manages the version, but the generated POM did not resolve it. The `versionMapping` configuration instructs Gradle to use the resolved versions from the classpath when generating POM files.

### Before (starter POM)
```xml
<dependency>
  <groupId>org.springframework.boot</groupId>
  <artifactId>spring-boot-starter</artifactId>
  <scope>runtime</scope>
  <!-- no version -->
</dependency>
```

### After (starter POM)
```xml
<dependency>
  <groupId>org.springframework.boot</groupId>
  <artifactId>spring-boot-starter</artifactId>
  <version>4.0.2</version>
  <scope>runtime</scope>
</dependency>
```

## Test plan

- [x] `./gradlew clean build` passes locally
- [x] Generated POM includes version for all dependencies
- [ ] CI passes