### PR TITLE
feat: suppress body capture for binary content types and oversized payloads

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -18,6 +18,8 @@ logback:
       enabled: false
       # include-hosts: localhost
       # exclude-hosts: internal.example.com
+      # max-payload-size: 65536
+      # allowed-content-types: text/*,application/json
     filter:
       # include-url-patterns:
       #   - /api/.*
@@ -37,6 +39,8 @@ logback:
 | `logback.access.tee-filter.enabled` | `false` | Enable request/response body capture |
 | `logback.access.tee-filter.include-hosts` | `null` | Comma-separated list of hosts to include |
 | `logback.access.tee-filter.exclude-hosts` | `null` | Comma-separated list of hosts to exclude |
+| `logback.access.tee-filter.max-payload-size` | `65536` | Maximum payload size (bytes) to log before suppression |
+| `logback.access.tee-filter.allowed-content-types` | `null` | Content-Type patterns allowed for body capture (override mode) |
 | `logback.access.filter.include-url-patterns` | `null` | URL patterns to include (regex) |
 | `logback.access.filter.exclude-url-patterns` | `null` | URL patterns to exclude (regex) |
 

--- a/docs/ja/guide/configuration.md
+++ b/docs/ja/guide/configuration.md
@@ -18,6 +18,8 @@ logback:
       enabled: false
       # include-hosts: localhost
       # exclude-hosts: internal.example.com
+      # max-payload-size: 65536
+      # allowed-content-types: text/*,application/json
     filter:
       # include-url-patterns:
       #   - /api/.*
@@ -37,6 +39,8 @@ logback:
 | `logback.access.tee-filter.enabled` | `false` | リクエスト/レスポンスボディキャプチャの有効化 |
 | `logback.access.tee-filter.include-hosts` | `null` | 含めるホストのカンマ区切りリスト |
 | `logback.access.tee-filter.exclude-hosts` | `null` | 除外するホストのカンマ区切りリスト |
+| `logback.access.tee-filter.max-payload-size` | `65536` | ログ出力する最大ペイロードサイズ（バイト） |
+| `logback.access.tee-filter.allowed-content-types` | `null` | ボディキャプチャを許可するContent-Typeパターン（上書きモード） |
 | `logback.access.filter.include-url-patterns` | `null` | 含めるURLパターン（正規表現） |
 | `logback.access.filter.exclude-url-patterns` | `null` | 除外するURLパターン（正規表現） |
 

--- a/logback-access-spring-boot-starter-core/api/logback-access-spring-boot-starter-core.api
+++ b/logback-access-spring-boot-starter-core/api/logback-access-spring-boot-starter-core.api
@@ -162,16 +162,20 @@ public final class io/github/seijikohara/spring/boot/logback/access/LogbackAcces
 }
 
 public final class io/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties {
-	public fun <init> (ZLjava/lang/String;Ljava/lang/String;)V
+	public fun <init> (ZLjava/lang/String;Ljava/lang/String;JLjava/util/List;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (ZLjava/lang/String;Ljava/lang/String;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;
-	public static synthetic fun copy$default (Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/String;JLjava/util/List;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;
+	public static synthetic fun copy$default (Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;ZLjava/lang/String;Ljava/lang/String;JLjava/util/List;ILjava/lang/Object;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties$TeeFilterProperties;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowedContentTypes ()Ljava/util/List;
 	public final fun getEnabled ()Z
 	public final fun getExcludeHosts ()Ljava/lang/String;
 	public final fun getIncludeHosts ()Ljava/lang/String;
+	public final fun getMaxPayloadSize ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties.kt
@@ -48,6 +48,14 @@ public data class LogbackAccessProperties
          * @property enabled Whether to enable the TeeFilter.
          * @property includeHosts Comma-separated host names to activate. All hosts when not specified.
          * @property excludeHosts Comma-separated host names to deactivate.
+         * @property maxPayloadSize Maximum payload size in bytes to include in log output.
+         *           Bodies exceeding this size are replaced with a sentinel value.
+         *           Note: This does not limit TeeFilter's internal buffering — the full body
+         *           is still buffered in memory by the upstream TeeFilter.
+         * @property allowedContentTypes Content-Type patterns allowed for body capture.
+         *           Supports type wildcards (e.g. "text/\*") and suffix patterns (e.g. "application/\*+json").
+         *           When null, uses built-in defaults (text types, application/json, etc.).
+         *           When specified, completely replaces the defaults (override mode).
          */
         public data class TeeFilterProperties
             @ConstructorBinding
@@ -56,6 +64,9 @@ public data class LogbackAccessProperties
                 val enabled: Boolean,
                 val includeHosts: String?,
                 val excludeHosts: String?,
+                @DefaultValue("65536")
+                val maxPayloadSize: Long,
+                val allowedContentTypes: List<String>?,
             )
 
         /**

--- a/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContextSpec.kt
+++ b/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContextSpec.kt
@@ -207,6 +207,8 @@ private fun createProperties(
                 enabled = false,
                 includeHosts = null,
                 excludeHosts = null,
+                maxPayloadSize = 65536L,
+                allowedContentTypes = null,
             ),
         filter =
             LogbackAccessProperties.FilterProperties(

--- a/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessPropertiesSpec.kt
+++ b/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessPropertiesSpec.kt
@@ -37,6 +37,8 @@ class LogbackAccessPropertiesSpec :
                             enabled = true,
                             includeHosts = "localhost,example.com",
                             excludeHosts = "internal.example.com",
+                            maxPayloadSize = 65536L,
+                            allowedContentTypes = listOf("text/*", "application/json"),
                         ),
                     filter =
                         LogbackAccessProperties.FilterProperties(
@@ -53,6 +55,8 @@ class LogbackAccessPropertiesSpec :
                 properties.teeFilter.enabled shouldBe true
                 properties.teeFilter.includeHosts shouldBe "localhost,example.com"
                 properties.teeFilter.excludeHosts shouldBe "internal.example.com"
+                properties.teeFilter.maxPayloadSize shouldBe 65536L
+                properties.teeFilter.allowedContentTypes shouldBe listOf("text/*", "application/json")
                 properties.filter.includeUrlPatterns shouldBe listOf("/api/.*")
                 properties.filter.excludeUrlPatterns shouldBe listOf("/health")
             }
@@ -68,6 +72,8 @@ class LogbackAccessPropertiesSpec :
                     enabled = false,
                     includeHosts = null,
                     excludeHosts = null,
+                    maxPayloadSize = 65536L,
+                    allowedContentTypes = null,
                 )
             val filter =
                 LogbackAccessProperties.FilterProperties(
@@ -80,6 +86,8 @@ class LogbackAccessPropertiesSpec :
                 teeFilter.enabled shouldBe false
                 teeFilter.includeHosts shouldBe null
                 teeFilter.excludeHosts shouldBe null
+                teeFilter.maxPayloadSize shouldBe 65536L
+                teeFilter.allowedContentTypes shouldBe null
                 filter.includeUrlPatterns shouldBe null
                 filter.excludeUrlPatterns shouldBe null
             }

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/BodyCapturePolicy.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/BodyCapturePolicy.kt
@@ -1,0 +1,88 @@
+package io.github.seijikohara.spring.boot.logback.access.tee
+
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties.TeeFilterProperties
+import java.nio.charset.Charset
+
+/**
+ * Evaluates whether captured body content should be included in log output
+ * or suppressed based on content type and payload size.
+ */
+internal object BodyCapturePolicy {
+    private const val IMAGE_CONTENTS_SUPPRESSED = "[IMAGE CONTENTS SUPPRESSED]"
+    private const val BINARY_CONTENT_SUPPRESSED = "[BINARY CONTENT SUPPRESSED]"
+    private const val CONTENT_TOO_LARGE = "[CONTENT TOO LARGE]"
+
+    private val DEFAULT_ALLOWED_CONTENT_TYPES =
+        listOf(
+            "text/*",
+            "application/json",
+            "application/xml",
+            "application/*+json",
+            "application/*+xml",
+            "application/x-www-form-urlencoded",
+        )
+
+    /**
+     * Evaluates whether body content should be suppressed.
+     *
+     * @return null if capture is allowed, or a sentinel string if suppressed.
+     */
+    fun evaluate(
+        contentType: String?,
+        payloadSize: Int,
+        properties: TeeFilterProperties,
+    ): String? =
+        when {
+            payloadSize > properties.maxPayloadSize -> CONTENT_TOO_LARGE
+            !isAllowedContentType(contentType, properties) -> selectBinarySentinel(contentType)
+            else -> null
+        }
+
+    /**
+     * Resolves a [Charset] from the given encoding name, falling back to UTF-8
+     * when the encoding is null or unsupported.
+     */
+    fun resolveCharset(encoding: String?): Charset = encoding?.let { runCatching { Charset.forName(it) }.getOrNull() } ?: Charsets.UTF_8
+
+    private fun isAllowedContentType(
+        contentType: String?,
+        properties: TeeFilterProperties,
+    ): Boolean {
+        if (contentType == null) return true
+        val mimeType = contentType.substringBefore(';').trim().lowercase()
+        val patterns = properties.allowedContentTypes ?: DEFAULT_ALLOWED_CONTENT_TYPES
+        return patterns.any { matchesMimePattern(mimeType, it.lowercase()) }
+    }
+
+    private fun selectBinarySentinel(contentType: String?): String {
+        val mimeType = contentType?.substringBefore(';')?.trim()?.lowercase()
+        return if (mimeType != null && mimeType.startsWith("image/")) {
+            IMAGE_CONTENTS_SUPPRESSED
+        } else {
+            BINARY_CONTENT_SUPPRESSED
+        }
+    }
+
+    private fun matchesMimePattern(
+        mimeType: String,
+        pattern: String,
+    ): Boolean =
+        when {
+            pattern == mimeType -> {
+                true
+            }
+
+            pattern.endsWith("/*") -> {
+                mimeType.startsWith(pattern.removeSuffix("*"))
+            }
+
+            pattern.contains("/*+") -> {
+                val (type, suffix) = pattern.split("/*+", limit = 2)
+                mimeType.startsWith("$type/") && mimeType.endsWith("+$suffix")
+            }
+
+            else -> {
+                false
+            }
+        }
+}

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSource.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSource.kt
@@ -39,11 +39,11 @@ internal fun createAccessEventData(
                 requestParameterMap = TomcatRequestDataExtractor.extractParameters(request),
                 attributeMap = TomcatRequestDataExtractor.extractAttributes(request),
                 sessionID = request.getSession(false)?.id,
-                requestContent = TomcatRequestDataExtractor.extractContent(request),
+                requestContent = TomcatRequestDataExtractor.extractContent(request, context.properties.teeFilter),
                 statusCode = response.status,
                 responseHeaderMap = TomcatResponseDataExtractor.extractHeaders(response),
                 contentLength = response.getBytesWritten(false),
-                responseContent = TomcatResponseDataExtractor.extractContent(request, response),
+                responseContent = TomcatResponseDataExtractor.extractContent(request, response, context.properties.teeFilter),
             )
         }
     }

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatResponseDataExtractor.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatResponseDataExtractor.kt
@@ -1,18 +1,16 @@
 package io.github.seijikohara.spring.boot.logback.access.tomcat
 
 import ch.qos.logback.access.common.AccessConstants.LB_OUTPUT_BUFFER
-import ch.qos.logback.access.common.servlet.Util.isImageResponse
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties.TeeFilterProperties
+import io.github.seijikohara.spring.boot.logback.access.tee.BodyCapturePolicy
 import org.apache.catalina.connector.Request
 import org.apache.catalina.connector.Response
-import java.nio.charset.Charset
 import java.util.Collections.unmodifiableMap
 
 /**
  * Extracts response data (headers, content) from Tomcat [Response].
  */
 internal object TomcatResponseDataExtractor {
-    private const val IMAGE_CONTENTS_SUPPRESSED = "[IMAGE CONTENTS SUPPRESSED]"
-
     fun extractHeaders(response: Response): Map<String, String> =
         sortedMapOf<String, String>(String.CASE_INSENSITIVE_ORDER)
             .also { headers ->
@@ -22,24 +20,17 @@ internal object TomcatResponseDataExtractor {
     /**
      * Extracts response body content captured by TeeFilter.
      *
+     * Evaluates body capture policy (content type and size) before conversion.
      * Uses the response's character encoding for byte-to-string conversion,
      * falling back to UTF-8 when the encoding is not specified or unsupported.
      */
     fun extractContent(
         request: Request,
         response: Response,
-    ): String? =
-        when {
-            isImageResponse(response) -> {
-                IMAGE_CONTENTS_SUPPRESSED
-            }
-
-            else -> {
-                (request.getAttribute(LB_OUTPUT_BUFFER) as? ByteArray)
-                    ?.let { String(it, resolveCharset(response.characterEncoding)) }
-            }
-        }
-
-    private fun resolveCharset(encoding: String?): Charset =
-        encoding?.let { runCatching { Charset.forName(it) }.getOrNull() } ?: Charsets.UTF_8
+        teeFilterProperties: TeeFilterProperties,
+    ): String? {
+        val buffer = request.getAttribute(LB_OUTPUT_BUFFER) as? ByteArray ?: return null
+        return BodyCapturePolicy.evaluate(response.contentType, buffer.size, teeFilterProperties)
+            ?: String(buffer, BodyCapturePolicy.resolveCharset(response.characterEncoding))
+    }
 }

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/BodyCapturePolicySpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/BodyCapturePolicySpec.kt
@@ -1,0 +1,129 @@
+package io.github.seijikohara.spring.boot.logback.access.tee
+
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties.TeeFilterProperties
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class BodyCapturePolicySpec :
+    FunSpec({
+        val defaultProperties =
+            TeeFilterProperties(
+                enabled = true,
+                includeHosts = null,
+                excludeHosts = null,
+                maxPayloadSize = 65536L,
+                allowedContentTypes = null,
+            )
+
+        context("evaluate — text content types") {
+            test("allows text/plain") {
+                BodyCapturePolicy.evaluate("text/plain", 100, defaultProperties) shouldBe null
+            }
+
+            test("allows text/html with charset") {
+                BodyCapturePolicy.evaluate("text/html; charset=UTF-8", 100, defaultProperties) shouldBe null
+            }
+
+            test("allows application/json") {
+                BodyCapturePolicy.evaluate("application/json", 100, defaultProperties) shouldBe null
+            }
+
+            test("allows application/xml") {
+                BodyCapturePolicy.evaluate("application/xml", 100, defaultProperties) shouldBe null
+            }
+
+            test("allows application/vnd.api+json") {
+                BodyCapturePolicy.evaluate("application/vnd.api+json", 100, defaultProperties) shouldBe null
+            }
+
+            test("allows application/atom+xml") {
+                BodyCapturePolicy.evaluate("application/atom+xml", 100, defaultProperties) shouldBe null
+            }
+
+            test("allows application/x-www-form-urlencoded") {
+                BodyCapturePolicy.evaluate("application/x-www-form-urlencoded", 100, defaultProperties) shouldBe null
+            }
+        }
+
+        context("evaluate — binary content types") {
+            test("suppresses image/png with IMAGE sentinel") {
+                BodyCapturePolicy.evaluate("image/png", 100, defaultProperties) shouldBe
+                    "[IMAGE CONTENTS SUPPRESSED]"
+            }
+
+            test("suppresses image/jpeg with IMAGE sentinel") {
+                BodyCapturePolicy.evaluate("image/jpeg", 100, defaultProperties) shouldBe
+                    "[IMAGE CONTENTS SUPPRESSED]"
+            }
+
+            test("suppresses video/mp4 with BINARY sentinel") {
+                BodyCapturePolicy.evaluate("video/mp4", 100, defaultProperties) shouldBe
+                    "[BINARY CONTENT SUPPRESSED]"
+            }
+
+            test("suppresses application/octet-stream with BINARY sentinel") {
+                BodyCapturePolicy.evaluate("application/octet-stream", 100, defaultProperties) shouldBe
+                    "[BINARY CONTENT SUPPRESSED]"
+            }
+
+            test("suppresses audio/mpeg with BINARY sentinel") {
+                BodyCapturePolicy.evaluate("audio/mpeg", 100, defaultProperties) shouldBe
+                    "[BINARY CONTENT SUPPRESSED]"
+            }
+        }
+
+        context("evaluate — size limit") {
+            test("suppresses payload exceeding maxPayloadSize") {
+                BodyCapturePolicy.evaluate("text/plain", 70000, defaultProperties) shouldBe
+                    "[CONTENT TOO LARGE]"
+            }
+
+            test("allows payload at exactly maxPayloadSize") {
+                BodyCapturePolicy.evaluate("text/plain", 65536, defaultProperties) shouldBe null
+            }
+
+            test("size check takes precedence over content type") {
+                BodyCapturePolicy.evaluate("application/octet-stream", 70000, defaultProperties) shouldBe
+                    "[CONTENT TOO LARGE]"
+            }
+        }
+
+        context("evaluate — custom allowed content types") {
+            test("uses custom list when specified (override mode)") {
+                val customProperties =
+                    defaultProperties.copy(
+                        allowedContentTypes = listOf("application/pdf"),
+                    )
+                BodyCapturePolicy.evaluate("application/pdf", 100, customProperties) shouldBe null
+            }
+
+            test("rejects previously allowed type when custom list excludes it") {
+                val customProperties =
+                    defaultProperties.copy(
+                        allowedContentTypes = listOf("application/pdf"),
+                    )
+                BodyCapturePolicy.evaluate("text/plain", 100, customProperties) shouldBe
+                    "[BINARY CONTENT SUPPRESSED]"
+            }
+        }
+
+        context("evaluate — null content type") {
+            test("allows null content type (treated as text)") {
+                BodyCapturePolicy.evaluate(null, 100, defaultProperties) shouldBe null
+            }
+        }
+
+        context("resolveCharset") {
+            test("resolves Shift_JIS") {
+                BodyCapturePolicy.resolveCharset("Shift_JIS").name() shouldBe "Shift_JIS"
+            }
+
+            test("falls back to UTF-8 for null encoding") {
+                BodyCapturePolicy.resolveCharset(null) shouldBe Charsets.UTF_8
+            }
+
+            test("falls back to UTF-8 for invalid encoding") {
+                BodyCapturePolicy.resolveCharset("INVALID-CHARSET") shouldBe Charsets.UTF_8
+            }
+        }
+    })

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestDataExtractorSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestDataExtractorSpec.kt
@@ -1,6 +1,7 @@
 package io.github.seijikohara.spring.boot.logback.access.tomcat
 
 import ch.qos.logback.access.common.AccessConstants.LB_INPUT_BUFFER
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties.TeeFilterProperties
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -9,13 +10,23 @@ import org.apache.catalina.connector.Request
 
 class TomcatRequestDataExtractorSpec :
     FunSpec({
+        val defaultProperties =
+            TeeFilterProperties(
+                enabled = true,
+                includeHosts = null,
+                excludeHosts = null,
+                maxPayloadSize = 65536L,
+                allowedContentTypes = null,
+            )
+
         test("extractContent uses request character encoding for byte array conversion") {
             val request = mockk<Request>(relaxed = true)
             val shiftJisBytes = "テスト".toByteArray(charset("Shift_JIS"))
             every { request.getAttribute(LB_INPUT_BUFFER) } returns shiftJisBytes
             every { request.characterEncoding } returns "Shift_JIS"
+            every { request.contentType } returns "text/plain"
 
-            val content = TomcatRequestDataExtractor.extractContent(request)
+            val content = TomcatRequestDataExtractor.extractContent(request, defaultProperties)
 
             content shouldBe "テスト"
         }
@@ -25,8 +36,9 @@ class TomcatRequestDataExtractorSpec :
             val utf8Bytes = "hello".toByteArray(Charsets.UTF_8)
             every { request.getAttribute(LB_INPUT_BUFFER) } returns utf8Bytes
             every { request.characterEncoding } returns null
+            every { request.contentType } returns "text/plain"
 
-            val content = TomcatRequestDataExtractor.extractContent(request)
+            val content = TomcatRequestDataExtractor.extractContent(request, defaultProperties)
 
             content shouldBe "hello"
         }
@@ -36,8 +48,9 @@ class TomcatRequestDataExtractorSpec :
             val utf8Bytes = "hello".toByteArray(Charsets.UTF_8)
             every { request.getAttribute(LB_INPUT_BUFFER) } returns utf8Bytes
             every { request.characterEncoding } returns "INVALID-CHARSET-NAME"
+            every { request.contentType } returns "application/json"
 
-            val content = TomcatRequestDataExtractor.extractContent(request)
+            val content = TomcatRequestDataExtractor.extractContent(request, defaultProperties)
 
             content shouldBe "hello"
         }
@@ -47,8 +60,30 @@ class TomcatRequestDataExtractorSpec :
             every { request.getAttribute(LB_INPUT_BUFFER) } returns null
             every { request.contentType } returns "application/json"
 
-            val content = TomcatRequestDataExtractor.extractContent(request)
+            val content = TomcatRequestDataExtractor.extractContent(request, defaultProperties)
 
             content shouldBe null
+        }
+
+        test("extractContent suppresses binary content") {
+            val request = mockk<Request>(relaxed = true)
+            val binaryBytes = ByteArray(100) { 0xFF.toByte() }
+            every { request.getAttribute(LB_INPUT_BUFFER) } returns binaryBytes
+            every { request.contentType } returns "application/octet-stream"
+
+            val content = TomcatRequestDataExtractor.extractContent(request, defaultProperties)
+
+            content shouldBe "[BINARY CONTENT SUPPRESSED]"
+        }
+
+        test("extractContent suppresses oversized payload") {
+            val request = mockk<Request>(relaxed = true)
+            val largeBytes = ByteArray(70000) { 'a'.code.toByte() }
+            every { request.getAttribute(LB_INPUT_BUFFER) } returns largeBytes
+            every { request.contentType } returns "text/plain"
+
+            val content = TomcatRequestDataExtractor.extractContent(request, defaultProperties)
+
+            content shouldBe "[CONTENT TOO LARGE]"
         }
     })

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatResponseDataExtractorSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatResponseDataExtractorSpec.kt
@@ -1,6 +1,7 @@
 package io.github.seijikohara.spring.boot.logback.access.tomcat
 
 import ch.qos.logback.access.common.AccessConstants.LB_OUTPUT_BUFFER
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties.TeeFilterProperties
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -10,6 +11,15 @@ import org.apache.catalina.connector.Response
 
 class TomcatResponseDataExtractorSpec :
     FunSpec({
+        val defaultProperties =
+            TeeFilterProperties(
+                enabled = true,
+                includeHosts = null,
+                excludeHosts = null,
+                maxPayloadSize = 65536L,
+                allowedContentTypes = null,
+            )
+
         test("extractContent uses response character encoding for byte array conversion") {
             val request = mockk<Request>(relaxed = true)
             val response = mockk<Response>(relaxed = true)
@@ -18,7 +28,7 @@ class TomcatResponseDataExtractorSpec :
             every { response.characterEncoding } returns "ISO-8859-1"
             every { response.contentType } returns "text/plain"
 
-            val content = TomcatResponseDataExtractor.extractContent(request, response)
+            val content = TomcatResponseDataExtractor.extractContent(request, response, defaultProperties)
 
             content shouldBe "café"
         }
@@ -31,7 +41,7 @@ class TomcatResponseDataExtractorSpec :
             every { response.characterEncoding } returns null
             every { response.contentType } returns "text/plain"
 
-            val content = TomcatResponseDataExtractor.extractContent(request, response)
+            val content = TomcatResponseDataExtractor.extractContent(request, response, defaultProperties)
 
             content shouldBe "hello"
         }
@@ -39,9 +49,11 @@ class TomcatResponseDataExtractorSpec :
         test("extractContent returns sentinel for image response") {
             val request = mockk<Request>(relaxed = true)
             val response = mockk<Response>(relaxed = true)
+            val imageBytes = ByteArray(100) { 0x89.toByte() }
+            every { request.getAttribute(LB_OUTPUT_BUFFER) } returns imageBytes
             every { response.contentType } returns "image/png"
 
-            val content = TomcatResponseDataExtractor.extractContent(request, response)
+            val content = TomcatResponseDataExtractor.extractContent(request, response, defaultProperties)
 
             content shouldBe "[IMAGE CONTENTS SUPPRESSED]"
         }
@@ -52,8 +64,33 @@ class TomcatResponseDataExtractorSpec :
             every { request.getAttribute(LB_OUTPUT_BUFFER) } returns null
             every { response.contentType } returns "text/plain"
 
-            val content = TomcatResponseDataExtractor.extractContent(request, response)
+            val content = TomcatResponseDataExtractor.extractContent(request, response, defaultProperties)
 
             content shouldBe null
+        }
+
+        test("extractContent suppresses binary content") {
+            val request = mockk<Request>(relaxed = true)
+            val response = mockk<Response>(relaxed = true)
+            val binaryBytes = ByteArray(100)
+            every { request.getAttribute(LB_OUTPUT_BUFFER) } returns binaryBytes
+            every { response.contentType } returns "video/mp4"
+
+            val content = TomcatResponseDataExtractor.extractContent(request, response, defaultProperties)
+
+            content shouldBe "[BINARY CONTENT SUPPRESSED]"
+        }
+
+        test("extractContent suppresses oversized payload") {
+            val request = mockk<Request>(relaxed = true)
+            val response = mockk<Response>(relaxed = true)
+            val largeBytes = ByteArray(70000) { 'x'.code.toByte() }
+            every { request.getAttribute(LB_OUTPUT_BUFFER) } returns largeBytes
+            every { response.characterEncoding } returns "UTF-8"
+            every { response.contentType } returns "application/json"
+
+            val content = TomcatResponseDataExtractor.extractContent(request, response, defaultProperties)
+
+            content shouldBe "[CONTENT TOO LARGE]"
         }
     })


### PR DESCRIPTION
## Summary

- Add `BodyCapturePolicy` to evaluate whether captured body content should be included in log output or replaced with sentinel values
- Add `maxPayloadSize` and `allowedContentTypes` properties to `TeeFilterProperties` for configurable body capture control
- Consolidate `resolveCharset` and image detection logic from Tomcat extractors into the new policy object

## Changes

### New
- `tee/BodyCapturePolicy.kt` — Content-type and size evaluation with MIME pattern matching
- `tee/BodyCapturePolicySpec.kt` — 21 test cases covering text/binary/size/custom/charset scenarios

### Modified
- `LogbackAccessProperties.kt` — Added `maxPayloadSize` (default 65536) and `allowedContentTypes` to TeeFilterProperties
- `TomcatRequestDataExtractor.kt` — Delegates to BodyCapturePolicy for content evaluation and charset resolution
- `TomcatResponseDataExtractor.kt` — Same delegation, removed `IMAGE_CONTENTS_SUPPRESSED` and `isImageResponse`
- `TomcatEventSource.kt` — Passes `teeFilter` properties to extractors
- API dump updated for new TeeFilterProperties constructor

### Documentation
- EN/JA advanced.md — Added Body Capture Policy section with defaults, sentinel values, custom config
- EN/JA configuration.md — Added `max-payload-size` and `allowed-content-types` to property reference

## Test plan
- [x] `./gradlew clean build -x spotlessKotlinGradleCheck` — BUILD SUCCESSFUL (60 tasks)
- [x] BodyCapturePolicySpec — 21 tests covering all evaluation paths
- [x] TomcatRequestDataExtractorSpec — Updated + 2 new tests (binary, oversized)
- [x] TomcatResponseDataExtractorSpec — Updated + 2 new tests (binary, oversized)
- [x] `apiCheck` — Binary compatibility verified

Closes #45