### PR TITLE
fix: exclude anonymous authentication from remoteUser resolution

### DIFF
--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -225,7 +225,20 @@ Automatic username capture requires a Servlet-based web application (Spring MVC)
 The starter checks the `SecurityContextHolder` for the authenticated principal:
 
 1. Authenticated requests: The starter captures the username in `%u`
-2. Anonymous requests: The starter shows `-`
+2. Anonymous requests: The `%u` variable shows `-`
+
+Anonymous authentication tokens (such as `AnonymousAuthenticationToken`) are excluded using an `AuthenticationTrustResolver`. Only genuinely authenticated users appear in the access log.
+
+### Customizing Trust Resolution
+
+The starter provides a default `AuthenticationTrustResolver` bean (`AuthenticationTrustResolverImpl`). You can override it by defining your own bean:
+
+```java
+@Bean
+public AuthenticationTrustResolver authenticationTrustResolver() {
+    return new MyCustomTrustResolver();
+}
+```
 
 ### Custom Principal Extraction
 

--- a/docs/ja/guide/advanced.md
+++ b/docs/ja/guide/advanced.md
@@ -225,7 +225,20 @@ Spring Securityがクラスパスにある場合、スターターは認証済�
 スターターは認証済みプリンシパルの`SecurityContextHolder`をチェックします:
 
 1. 認証済みリクエスト: ユーザー名が`%u`でキャプチャされる
-2. 匿名リクエスト: `-`が表示される
+2. 匿名リクエスト: `%u`変数は`-`を表示
+
+匿名認証トークン（`AnonymousAuthenticationToken`など）は`AuthenticationTrustResolver`を使用して除外されます。アクセスログには実際に認証されたユーザーのみが記録されます。
+
+### 信頼解決のカスタマイズ
+
+スターターはデフォルトの`AuthenticationTrustResolver` Bean（`AuthenticationTrustResolverImpl`）を提供します。独自のBeanを定義することでオーバーライドできます:
+
+```java
+@Bean
+public AuthenticationTrustResolver authenticationTrustResolver() {
+    return new MyCustomTrustResolver();
+}
+```
 
 ### カスタムプリンシパル抽出
 

--- a/examples/common/src/main/java/io/github/seijikohara/examples/AbstractSecurityTest.java
+++ b/examples/common/src/main/java/io/github/seijikohara/examples/AbstractSecurityTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractSecurityTest {
     }
 
     @Test
-    void unauthenticatedRequestOnPublicEndpointHasAnonymousUser() throws Exception {
+    void unauthenticatedRequestOnPublicEndpointHasNoUser() throws Exception {
         final var response = HttpClientTestUtils.get(getBaseUrl() + "/api/public");
 
         assertThat(response.statusCode()).isEqualTo(200);
@@ -82,8 +82,8 @@ public abstract class AbstractSecurityTest {
 
         assertThat(events).hasSize(1);
         final var event = events.get(0);
-        // Spring Security sets anonymous user when security filter chain is applied
-        assertThat(event.getRemoteUser()).isEqualTo("anonymousUser");
+        // Anonymous authentication tokens are excluded from remoteUser
+        assertThat(event.getRemoteUser()).isEqualTo("-");
     }
 
     @Test

--- a/logback-access-spring-boot-starter/build.gradle.kts
+++ b/logback-access-spring-boot-starter/build.gradle.kts
@@ -60,6 +60,7 @@ testing {
                 implementation(libs.mockk)
                 implementation("org.springframework:spring-test")
                 implementation(libs.spring.boot.starter.tomcat)
+                implementation(libs.spring.boot.starter.security)
             }
         }
     }

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/security/SecurityConfiguration.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/security/SecurityConfiguration.kt
@@ -1,12 +1,15 @@
 package io.github.seijikohara.spring.boot.logback.access.security
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type.SERVLET
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.Ordered
+import org.springframework.security.authentication.AuthenticationTrustResolver
+import org.springframework.security.authentication.AuthenticationTrustResolverImpl
 import org.springframework.security.web.SecurityFilterChain
 
 /**
@@ -14,14 +17,22 @@ import org.springframework.security.web.SecurityFilterChain
  *
  * The filter is ordered after the Spring Security filter chain so that
  * the authentication context is available when the filter executes.
+ *
+ * A default [AuthenticationTrustResolver] is provided to distinguish
+ * anonymous tokens from genuinely authenticated users. Users can
+ * override this bean to customize the trust resolution logic.
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(SecurityFilterChain::class)
 @ConditionalOnWebApplication(type = SERVLET)
 internal class SecurityConfiguration {
     @Bean
-    fun logbackAccessSecurityFilter(): FilterRegistrationBean<SecurityFilter> =
-        FilterRegistrationBean(SecurityFilter()).apply {
+    @ConditionalOnMissingBean(AuthenticationTrustResolver::class)
+    fun logbackAccessAuthenticationTrustResolver(): AuthenticationTrustResolver = AuthenticationTrustResolverImpl()
+
+    @Bean
+    fun logbackAccessSecurityFilter(trustResolver: AuthenticationTrustResolver): FilterRegistrationBean<SecurityFilter> =
+        FilterRegistrationBean(SecurityFilter(trustResolver)).apply {
             order = Ordered.LOWEST_PRECEDENCE - ORDER_OFFSET
             addUrlPatterns("/*")
         }

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/security/SecurityFilterSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/security/SecurityFilterSpec.kt
@@ -1,0 +1,120 @@
+package io.github.seijikohara.spring.boot.logback.access.security
+
+import io.github.seijikohara.spring.boot.logback.access.AccessEventData.Companion.REMOTE_USER_ATTR
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.AnonymousAuthenticationToken
+import org.springframework.security.authentication.AuthenticationTrustResolver
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.authority.AuthorityUtils
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.core.context.SecurityContextImpl
+
+class SecurityFilterSpec :
+    FunSpec({
+        lateinit var request: HttpServletRequest
+        lateinit var response: HttpServletResponse
+        lateinit var filterChain: FilterChain
+
+        beforeEach {
+            request =
+                mockk(relaxed = true) {
+                    every { getAttribute(any()) } returns null
+                }
+            response = mockk(relaxed = true)
+            filterChain = mockk(relaxed = true)
+            SecurityContextHolder.clearContext()
+        }
+
+        afterEach {
+            SecurityContextHolder.clearContext()
+        }
+
+        context("authenticated user") {
+            test("sets REMOTE_USER_ATTR with username") {
+                setAuthentication(
+                    UsernamePasswordAuthenticationToken("testuser", "password", emptyList()),
+                )
+                val filter = SecurityFilter()
+
+                filter.doFilter(request, response, filterChain)
+
+                verify { request.setAttribute(REMOTE_USER_ATTR, "testuser") }
+                verify { filterChain.doFilter(request, response) }
+            }
+        }
+
+        context("anonymous authentication") {
+            test("does not set REMOTE_USER_ATTR for AnonymousAuthenticationToken") {
+                setAuthentication(
+                    AnonymousAuthenticationToken(
+                        "key",
+                        "anonymousUser",
+                        AuthorityUtils.createAuthorityList("ROLE_ANONYMOUS"),
+                    ),
+                )
+                val filter = SecurityFilter()
+
+                filter.doFilter(request, response, filterChain)
+
+                verify(exactly = 0) { request.setAttribute(REMOTE_USER_ATTR, any()) }
+                verify { filterChain.doFilter(request, response) }
+            }
+        }
+
+        context("no authentication") {
+            test("does not set REMOTE_USER_ATTR when authentication is null") {
+                SecurityContextHolder.setContext(SecurityContextImpl())
+                val filter = SecurityFilter()
+
+                filter.doFilter(request, response, filterChain)
+
+                verify(exactly = 0) { request.setAttribute(REMOTE_USER_ATTR, any()) }
+                verify { filterChain.doFilter(request, response) }
+            }
+        }
+
+        context("custom AuthenticationTrustResolver") {
+            test("delegates anonymous check to provided trust resolver") {
+                val auth = UsernamePasswordAuthenticationToken("testuser", "password", emptyList())
+                setAuthentication(auth)
+                val customResolver =
+                    mockk<AuthenticationTrustResolver> {
+                        every { isAnonymous(auth) } returns true
+                    }
+                val filter = SecurityFilter(customResolver)
+
+                filter.doFilter(request, response, filterChain)
+
+                verify(exactly = 0) { request.setAttribute(REMOTE_USER_ATTR, any()) }
+                verify { customResolver.isAnonymous(auth) }
+                verify { filterChain.doFilter(request, response) }
+            }
+        }
+
+        context("filter chain invocation") {
+            test("always invokes filter chain regardless of authentication state") {
+                SecurityContextHolder.clearContext()
+                val filter = SecurityFilter()
+
+                filter.doFilter(request, response, filterChain)
+
+                verify { filterChain.doFilter(request, response) }
+            }
+        }
+    }) {
+    companion object {
+        private fun setAuthentication(authentication: Authentication) {
+            val context = SecurityContextImpl()
+            context.authentication = authentication
+            SecurityContextHolder.setContext(context)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Exclude `AnonymousAuthenticationToken` from `remoteUser` using `AuthenticationTrustResolver`
- Register default `AuthenticationTrustResolver` bean with `@ConditionalOnMissingBean` for customization
- Add `SecurityFilterSpec` unit tests covering authenticated, anonymous, null auth, and custom resolver scenarios
- Update EN/JA documentation to describe anonymous exclusion behavior and trust resolver customization

## Changes
- `SecurityFilter.kt` — Add `AuthenticationTrustResolver` parameter and `!trustResolver.isAnonymous(it)` check
- `SecurityConfiguration.kt` — Register `AuthenticationTrustResolverImpl` as default bean
- `AbstractSecurityTest.java` — Update expected value for anonymous user from `"anonymousUser"` to `"-"`
- `SecurityFilterSpec.kt` — New unit test (5 test cases)
- `build.gradle.kts` — Add `spring-boot-starter-security` to test dependencies
- `docs/guide/advanced.md` / `docs/ja/guide/advanced.md` — Document anonymous exclusion and trust resolver customization

## Test plan
- [x] `SecurityFilterSpec` — 5 tests covering all authentication states
- [x] Integration tests — `AbstractSecurityTest` verifies anonymous user returns `-`
- [x] Full build passes: `./gradlew clean build -x spotlessKotlinGradleCheck -x spotlessCheck`

Closes #48