### PR TITLE
fix: use Tomcat AccessLog time parameter and avoid catching fatal errors

### DIFF
--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContext.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContext.kt
@@ -53,18 +53,18 @@ public class LogbackAccessContext(
      * 2. Logback filter chain evaluation
      * 3. Appender invocation
      *
-     * Exceptions from appenders are caught and logged at ERROR level to prevent
-     * application crashes due to logging failures. Check the application log
-     * for error messages if events are not appearing.
+     * Only [Exception] subclasses are caught and logged at ERROR level.
+     * Fatal errors ([Error]) are propagated to the caller.
      */
+    @Suppress("TooGenericExceptionCaught")
     public fun emit(event: LogbackAccessEvent) {
-        runCatching {
+        try {
             event
                 .takeIf { shouldLog(it.requestURI) }
                 ?.let { accessContext.getFilterChainDecision(it) }
                 ?.takeIf { it != FilterReply.DENY }
                 ?.let { accessContext.callAppenders(event) }
-        }.onFailure { e ->
+        } catch (e: Exception) {
             logger.error(e) { "Failed to emit access event: ${event.requestURI}" }
         }
     }

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSource.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSource.kt
@@ -10,40 +10,44 @@ import org.apache.catalina.connector.Response
  *
  * All values are extracted eagerly so the returned data is safe for
  * deferred processing without holding references to Tomcat objects.
+ *
+ * @param elapsedTime the processing time in milliseconds provided by the Tomcat AccessLog contract.
+ *                    Falls back to computing from [Request.getCoyoteRequest] start time when negative.
  */
 internal fun createAccessEventData(
     context: LogbackAccessContext,
     request: Request,
     response: Response,
     requestAttributesEnabled: Boolean,
+    elapsedTime: Long,
 ): AccessEventData =
     TomcatRequestAttributeResolver(context, requestAttributesEnabled).let { resolver ->
-        System.currentTimeMillis().let { now ->
-            AccessEventData(
-                timeStamp = now,
-                elapsedTime = now - request.coyoteRequest.startTime,
-                sequenceNumber = context.accessContext.sequenceNumberGenerator?.nextSequenceNumber(),
-                threadName = Thread.currentThread().name,
-                serverName = resolver.resolveServerName(request),
-                localPort = resolver.resolveLocalPort(request),
-                remoteAddr = resolver.resolveRemoteAddr(request),
-                remoteHost = resolver.resolveRemoteHost(request),
-                remoteUser = resolver.resolveRemoteUser(request),
-                protocol = resolver.resolveProtocol(request),
-                method = request.method,
-                requestURI = request.requestURI,
-                queryString = request.queryString?.let { "?$it" }.orEmpty(),
-                requestURL = resolver.buildRequestURL(request),
-                requestHeaderMap = TomcatRequestDataExtractor.extractHeaders(request),
-                cookieMap = TomcatRequestDataExtractor.extractCookies(request),
-                requestParameterMap = TomcatRequestDataExtractor.extractParameters(request),
-                attributeMap = TomcatRequestDataExtractor.extractAttributes(request),
-                sessionID = request.getSession(false)?.id,
-                requestContent = TomcatRequestDataExtractor.extractContent(request, context.properties.teeFilter),
-                statusCode = response.status,
-                responseHeaderMap = TomcatResponseDataExtractor.extractHeaders(response),
-                contentLength = response.getBytesWritten(false),
-                responseContent = TomcatResponseDataExtractor.extractContent(request, response, context.properties.teeFilter),
-            )
-        }
+        AccessEventData(
+            timeStamp = System.currentTimeMillis(),
+            elapsedTime =
+                elapsedTime.takeIf { it >= 0 }
+                    ?: (System.currentTimeMillis() - request.coyoteRequest.startTime).coerceAtLeast(0),
+            sequenceNumber = context.accessContext.sequenceNumberGenerator?.nextSequenceNumber(),
+            threadName = Thread.currentThread().name,
+            serverName = resolver.resolveServerName(request),
+            localPort = resolver.resolveLocalPort(request),
+            remoteAddr = resolver.resolveRemoteAddr(request),
+            remoteHost = resolver.resolveRemoteHost(request),
+            remoteUser = resolver.resolveRemoteUser(request),
+            protocol = resolver.resolveProtocol(request),
+            method = request.method,
+            requestURI = request.requestURI,
+            queryString = request.queryString?.let { "?$it" }.orEmpty(),
+            requestURL = resolver.buildRequestURL(request),
+            requestHeaderMap = TomcatRequestDataExtractor.extractHeaders(request),
+            cookieMap = TomcatRequestDataExtractor.extractCookies(request),
+            requestParameterMap = TomcatRequestDataExtractor.extractParameters(request),
+            attributeMap = TomcatRequestDataExtractor.extractAttributes(request),
+            sessionID = request.getSession(false)?.id,
+            requestContent = TomcatRequestDataExtractor.extractContent(request, context.properties.teeFilter),
+            statusCode = response.status,
+            responseHeaderMap = TomcatResponseDataExtractor.extractHeaders(response),
+            contentLength = response.getBytesWritten(false),
+            responseContent = TomcatResponseDataExtractor.extractContent(request, response, context.properties.teeFilter),
+        )
     }

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValve.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValve.kt
@@ -46,7 +46,7 @@ internal class TomcatValve(
         response: Response,
         time: Long,
     ): Unit =
-        createAccessEventData(logbackAccessContext, request, response, requestAttributesEnabled)
+        createAccessEventData(logbackAccessContext, request, response, requestAttributesEnabled, time)
             .let { data -> LogbackAccessEvent(data, request, response) }
             .let(logbackAccessContext::emit)
 


### PR DESCRIPTION
## Summary
- Use the `time` parameter from Tomcat `AccessLog.log(request, response, time)` for elapsed time instead of independently computing it
- Replace `runCatching` (catches `Throwable` including `OutOfMemoryError`) with `try/catch(Exception)` in `LogbackAccessContext.emit()`

## Changes
- `TomcatValve.kt` — Pass `time` parameter to `createAccessEventData`
- `TomcatEventSource.kt` — Accept `elapsedTime` parameter; fall back to start time computation only when negative
- `LogbackAccessContext.kt` — Replace `runCatching` with `try/catch(Exception)`; add `@Suppress("TooGenericExceptionCaught")`

## Test plan
- [x] Full build passes: `./gradlew clean build -x spotlessKotlinGradleCheck -x spotlessCheck`
- [x] All integration tests pass (elapsed time is exercised end-to-end in Tomcat tests)
- [x] Detekt passes with `@Suppress` for the intentional generic catch

Closes #50, Closes #51