### PR TITLE
docs: fix documentation inconsistencies and update test paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,9 @@ The project contains both unit tests and integration tests:
 
 | Location | Type | Description |
 |----------|------|-------------|
-| `logback-access-spring-boot-starter-core/src/test/` | Unit tests | Core API and Joran extension tests (Kotest) |
-| `logback-access-spring-boot-starter/src/jettyTest/` | Integration tests | Jetty-specific tests |
-| `examples/` | Integration tests | Full Spring Boot tests for Tomcat/Jetty x MVC/WebFlux |
+| `logback-access-spring-boot-starter-core/src/test/` | Unit tests | Core API, Joran extensions, Properties (Kotest) |
+| `logback-access-spring-boot-starter/src/test/` | Unit tests | Body capture, Tomcat extractors, Security filter (Kotest) |
+| `examples/` | Integration tests | Full Spring Boot tests for Tomcat/Jetty × MVC/WebFlux |
 
 Run tests only:
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Use `%requestContent` and `%responseContent` patterns to access captured content
 | `logback.access.tee-filter.enabled` | Enable TeeFilter | `false` |
 | `logback.access.tee-filter.include-hosts` | Hosts to include (comma-separated) | All |
 | `logback.access.tee-filter.exclude-hosts` | Hosts to exclude (comma-separated) | None |
+| `logback.access.tee-filter.max-payload-size` | Maximum payload size (bytes) to log | `65536` |
+| `logback.access.tee-filter.allowed-content-types` | Content-Type patterns for body capture (override mode) | Text and JSON types |
 
 > **Security Warning**: TeeFilter captures request/response bodies which may contain sensitive data (passwords, tokens, PII). Use `include-hosts`/`exclude-hosts` to limit scope, and consider implementing custom masking in production environments.
 

--- a/docs/guide/tomcat.md
+++ b/docs/guide/tomcat.md
@@ -44,6 +44,10 @@ For standard pattern variables, see [Getting Started — Pattern Variables](/gui
 
 In addition to the standard variables, Tomcat supports all request attributes set by `RemoteIpValve` (e.g., `%{org.apache.catalina.AccessLog.RemoteAddr}r`). When `request-attributes-enabled` is `true`, these attributes reflect the real client information from behind a reverse proxy.
 
+## Elapsed Time
+
+The `%D` and `%T` pattern variables report the request processing time. When Tomcat provides this value directly (via the `AccessLog.log(request, response, time)` contract), the starter uses it as-is. If the value is not available, the starter computes it from the request start time.
+
 ## Behind a Reverse Proxy
 
 When running behind a proxy (nginx, Apache, load balancer), configure the `RemoteIpValve` to get the real client IP:

--- a/docs/ja/guide/tomcat.md
+++ b/docs/ja/guide/tomcat.md
@@ -44,6 +44,10 @@ logback:
 
 標準変数に加えて、Tomcatは`RemoteIpValve`が設定するすべてのリクエスト属性をサポートします（例: `%{org.apache.catalina.AccessLog.RemoteAddr}r`）。`request-attributes-enabled`が`true`の場合、これらの属性はリバースプロキシの背後にある実際のクライアント情報を反映します。
 
+## 経過時間
+
+`%D`と`%T`パターン変数はリクエスト処理時間を出力します。Tomcatが`AccessLog.log(request, response, time)`コントラクトで直接値を提供する場合、スターターはそのまま使用します。値が利用できない場合は、リクエスト開始時刻から計算します。
+
 ## リバースプロキシの背後での使用
 
 プロキシ（nginx、Apache、ロードバランサー）の背後で動作する場合、`RemoteIpValve`を設定して実際のクライアントIPを取得します:


### PR DESCRIPTION
## Summary

- Update CONTRIBUTING.md test location table to reflect current module structure (`src/jettyTest/` no longer exists)
- Add missing TeeFilter properties (`max-payload-size`, `allowed-content-types`) to README.md property table
- Document elapsed time behavior in Tomcat docs (EN/JA) explaining Tomcat-provided value vs computed fallback

## Test plan

- [x] `./gradlew clean build` passes
- [x] EN/JA documentation sections are structurally aligned
- [x] All referenced paths exist in the current project structure

Closes #54, Closes #55