### PR TITLE
fix: address Codex review findings from iteration 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,15 +196,17 @@ sequenceDiagram
     AccessLog->>AccessLog: Log with username
 ```
 
-The starter captures the authenticated username automatically when Spring Security is on the classpath:
+The starter captures the authenticated username automatically when Spring Security is on the classpath (Servlet applications only):
 
 ```
 127.0.0.1 - admin [06/Feb/2026:10:30:45 +0900] "GET /api/secure HTTP/1.1" 200 14
 ```
 
-No additional configuration is required.
+No additional configuration is required. For reactive applications (Spring WebFlux), access logging works but `%u` shows `-`.
 
 ### TeeFilter (Body Capture)
+
+> **Note**: TeeFilter is available for Servlet applications (Spring MVC with Tomcat) only. It is not supported on Jetty 12.
 
 Enable TeeFilter to capture request and response bodies:
 
@@ -223,7 +225,7 @@ Use `%requestContent` and `%responseContent` patterns to access captured content
 | `logback.access.tee-filter.include-hosts` | Hosts to include (comma-separated) | All |
 | `logback.access.tee-filter.exclude-hosts` | Hosts to exclude (comma-separated) | None |
 | `logback.access.tee-filter.max-payload-size` | Maximum payload size (bytes) to log | `65536` |
-| `logback.access.tee-filter.allowed-content-types` | Content-Type patterns for body capture (override mode) | Text and JSON types |
+| `logback.access.tee-filter.allowed-content-types` | Content-Type patterns for body capture (override mode) | Text, JSON, XML, and form types |
 
 > **Security Warning**: TeeFilter captures request/response bodies which may contain sensitive data (passwords, tokens, PII). Use `include-hosts`/`exclude-hosts` to limit scope, and consider implementing custom masking in production environments.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -90,6 +90,10 @@ The following pattern variables are available:
 | `%requestContent` | Request body (requires TeeFilter) |
 | `%responseContent` | Response body (requires TeeFilter) |
 
+::: tip Alternative Syntax
+For header, cookie, and attribute patterns, both `%{name}i` and `%i{name}` forms are supported. The examples in this documentation use the `%i{name}` form.
+:::
+
 ## Combined Log Format
 
 For a more detailed output similar to Apache's Combined Log Format:

--- a/docs/ja/guide/getting-started.md
+++ b/docs/ja/guide/getting-started.md
@@ -90,6 +90,10 @@ implementation 'io.github.seijikohara:logback-access-spring-boot-starter:VERSION
 | `%requestContent` | リクエストボディ（TeeFilterが必要） |
 | `%responseContent` | レスポンスボディ（TeeFilterが必要） |
 
+::: tip 代替構文
+ヘッダー、Cookie、属性パターンについては、`%{name}i`と`%i{name}`の両形式がサポートされています。本ドキュメントの例では`%i{name}`形式を使用しています。
+:::
+
 ## Combined Log Format
 
 ApacheのCombined Log Formatに近い詳細な出力:

--- a/examples/jetty-mvc/src/test/java/io/github/seijikohara/examples/jettymvc/JettyUrlFilteringTest.java
+++ b/examples/jetty-mvc/src/test/java/io/github/seijikohara/examples/jettymvc/JettyUrlFilteringTest.java
@@ -53,9 +53,7 @@ class JettyUrlFilteringTest {
         void excludedUrlDoesNotEmitEvent() throws Exception {
             HttpClientTestUtils.get(baseUrl() + "/api/health");
 
-            // Wait a bit and verify no events were emitted
-            Thread.sleep(500);
-            assertThat(listAppender.list).isEmpty();
+            AccessEventTestUtils.awaitNoEvents(listAppender);
         }
 
         @Test
@@ -112,9 +110,7 @@ class JettyUrlFilteringTest {
         void nonIncludedUrlDoesNotEmitEvent() throws Exception {
             HttpClientTestUtils.get(baseUrl() + "/api/greet");
 
-            // Wait a bit and verify no events were emitted
-            Thread.sleep(500);
-            assertThat(listAppender.list).isEmpty();
+            AccessEventTestUtils.awaitNoEvents(listAppender);
         }
     }
 
@@ -164,9 +160,7 @@ class JettyUrlFilteringTest {
         void includedAndExcludedUrlDoesNotEmitEvent() throws Exception {
             HttpClientTestUtils.get(baseUrl() + "/api/health");
 
-            // Wait a bit and verify no events were emitted
-            Thread.sleep(500);
-            assertThat(listAppender.list).isEmpty();
+            AccessEventTestUtils.awaitNoEvents(listAppender);
         }
     }
 }


### PR DESCRIPTION
## Summary

Addresses 5 issues identified during the Codex comprehensive project review:

- **Thread.sleep in jetty-mvc**: Replace remaining `Thread.sleep(500)` with `awaitNoEvents` in `JettyUrlFilteringTest.java` (missed in PR #59)
- **README Servlet-only notes**: Add notes that Spring Security username capture and TeeFilter are Servlet applications only
- **README allowed-content-types default**: Fix description from "Text and JSON types" to "Text, JSON, XML, and form types" to match `BodyCapturePolicy` defaults
- **Pattern notation tip**: Add tip to getting-started docs (EN/JA) explaining that both `%{xxx}i` and `%i{xxx}` forms are supported
- **Error propagation test**: Add test verifying `emit()` propagates `Error` (e.g., `OutOfMemoryError`) without catching

## Deferred items (next release)

- `AccessEventData` defensive copy (#6 in review)
- Jetty-specific constraint assertions (#8 in review)
- Elapsed time unit test (#2 in review — integration tests cover this)

## Test plan

- [x] `./gradlew clean build` passes (all 60 tasks)
- [x] New `propagates errors without catching` test passes
- [x] EN/JA documentation sections remain structurally aligned