### PR TITLE
fix: address Codex review findings from iteration 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ build
 # Ignore IntelliJ IDEA files
 .idea
 
+# Stray build artifacts
+META-INF/
+
 # VitePress
 docs/.vitepress/dist
 docs/.vitepress/cache

--- a/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,6 +1,0 @@
-org.springframework.boot.webmvc.autoconfigure.DispatcherServletAutoConfiguration
-org.springframework.boot.webmvc.autoconfigure.WebMvcAutoConfiguration
-org.springframework.boot.webmvc.autoconfigure.WebMvcObservationAutoConfiguration
-org.springframework.boot.webmvc.autoconfigure.actuate.endpoint.web.WebMvcHealthEndpointExtensionAutoConfiguration
-org.springframework.boot.webmvc.autoconfigure.actuate.web.mappings.WebMvcMappingsAutoConfiguration
-org.springframework.boot.webmvc.autoconfigure.error.ErrorMvcAutoConfiguration

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=b266d5ff6b90eada6dc3b20cb090e3731302e553a27c5d3e4df1f0d76beaff06
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContext.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContext.kt
@@ -27,6 +27,14 @@ public class LogbackAccessContext(
     /** The underlying Logback-access context. */
     public val accessContext: AccessContext = AccessContext()
 
+    /** Compiled regex patterns for URL filtering, cached for performance. */
+    private val includePatterns: List<Regex>? =
+        properties.filter.includeUrlPatterns?.map { Regex(it) }
+
+    /** Compiled regex patterns for URL exclusion, cached for performance. */
+    private val excludePatterns: List<Regex>? =
+        properties.filter.excludeUrlPatterns?.map { Regex(it) }
+
     init {
         val (name, resource) = resolveConfig(properties, resourceLoader)
         accessContext.name = name
@@ -36,14 +44,6 @@ public class LogbackAccessContext(
         accessContext.start()
         logger.debug { "Initialized LogbackAccessContext: $this" }
     }
-
-    /** Compiled regex patterns for URL filtering, cached for performance. */
-    private val includePatterns: List<Regex>? =
-        properties.filter.includeUrlPatterns?.map { Regex(it) }
-
-    /** Compiled regex patterns for URL exclusion, cached for performance. */
-    private val excludePatterns: List<Regex>? =
-        properties.filter.excludeUrlPatterns?.map { Regex(it) }
 
     /**
      * Emits an access event through the filter chain and appenders.

--- a/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/AccessEventDataSpec.kt
+++ b/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/AccessEventDataSpec.kt
@@ -78,6 +78,18 @@ class AccessEventDataSpec :
             deserialized shouldBe original
         }
 
+        test("requestParameterArrayMap is accessible after deserialization") {
+            val original = createTestData(requestParameterMap = mapOf("key" to listOf("v1", "v2")))
+
+            val baos = ByteArrayOutputStream()
+            ObjectOutputStream(baos).use { it.writeObject(original) }
+
+            val bais = ByteArrayInputStream(baos.toByteArray())
+            val deserialized = ObjectInputStream(bais).use { it.readObject() as AccessEventData }
+
+            deserialized.requestParameterArrayMap["key"] shouldBe arrayOf("v1", "v2")
+        }
+
         test("copy creates independent instance") {
             val original = createTestData()
             val copied = original.copy(statusCode = 404)

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/TeeFilterConfiguration.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/TeeFilterConfiguration.kt
@@ -5,6 +5,7 @@ import ch.qos.logback.access.common.AccessConstants.TEE_FILTER_INCLUDES_PARAM
 import ch.qos.logback.access.common.servlet.TeeFilter
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type.SERVLET
 import org.springframework.boot.web.servlet.FilterRegistrationBean
@@ -15,11 +16,14 @@ import org.springframework.core.Ordered
 /**
  * Registers the Logback-access [TeeFilter] for capturing request/response bodies.
  *
- * Activated when `logback.access.tee-filter.enabled` is `true`.
+ * Activated when `logback.access.tee-filter.enabled` is `true` and Tomcat is on the classpath.
+ * TeeFilter is not supported on Jetty because the Jetty event source uses the native
+ * [org.eclipse.jetty.server.RequestLog] API, which does not expose Servlet filter attributes.
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnBooleanProperty(prefix = "logback.access.tee-filter", name = ["enabled"])
 @ConditionalOnWebApplication(type = SERVLET)
+@ConditionalOnClass(name = ["org.apache.catalina.startup.Tomcat"])
 internal class TeeFilterConfiguration {
     @Bean
     fun logbackAccessTeeFilter(properties: LogbackAccessProperties): FilterRegistrationBean<TeeFilter> =

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessAutoConfigurationSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessAutoConfigurationSpec.kt
@@ -149,6 +149,15 @@ class LogbackAccessAutoConfigurationSpec :
                     assertThat(context).doesNotHaveBean("logbackAccessTeeFilter")
                 }
             }
+
+            test("does not create TeeFilter bean when Tomcat is absent") {
+                baseRunner()
+                    .withPropertyValues("logback.access.tee-filter.enabled=true")
+                    .withClassLoader(FilteredClassLoader(Tomcat::class.java))
+                    .run { context ->
+                        assertThat(context).doesNotHaveBean("logbackAccessTeeFilter")
+                    }
+            }
         }
     })
 


### PR DESCRIPTION
## Summary
- **[CRITICAL]** Apply `BodyCapturePolicy` to form data fallback path in `TomcatRequestDataExtractor` — prevents bypassing `max-payload-size` and `allowed-content-types` for reconstructed form data
- **[WARNING]** Replace `@delegate:Transient lazy` with computed property in `AccessEventData` — fixes NPE after Java deserialization
- **[WARNING]** Move regex pattern compilation before `accessContext.start()` in `LogbackAccessContext` — prevents resource leak on invalid patterns
- **[WARNING]** Limit TeeFilter registration to Tomcat via `@ConditionalOnClass` — Jetty native `RequestLog` API does not expose Servlet filter attributes
- **[WARNING]** Fix KDoc accuracy for `AccessEventData` immutability claim
- **[WARNING]** Add Gradle wrapper `distributionSha256Sum` for supply-chain security
- **[WARNING]** Remove stray root `META-INF/` directory and add to `.gitignore`
- Add tests for deserialization, form data policy enforcement, and TeeFilter Tomcat-only condition

## Test plan
- [x] All existing tests pass (60 tasks, 0 failures)
- [x] New deserialization test for `AccessEventData.requestParameterArrayMap`
- [x] New form data + `max-payload-size` test for `TomcatRequestDataExtractor`
- [x] New form data + `allowed-content-types` test for `TomcatRequestDataExtractor`
- [x] New TeeFilter Tomcat-absent test in `LogbackAccessAutoConfigurationSpec`
- [x] `./gradlew clean build` succeeds
- [ ] CI pipeline passes