### PR TITLE
docs: fix verification findings in README and detekt config

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Access logs appear in the console:
 |----------|-------------|---------|
 | `logback.access.enabled` | Enable/disable access logging | `true` |
 | `logback.access.config-location` | Custom configuration file path | Auto-detected |
-| `logback.access.local-port-strategy` | Port resolution: `SERVER` or `LOCAL` | `SERVER` |
+| `logback.access.local-port-strategy` | Port resolution: `server` or `local` | `server` |
 | `logback.access.filter.include-url-patterns` | Regex patterns for URLs to include | All URLs |
 | `logback.access.filter.exclude-url-patterns` | Regex patterns for URLs to exclude | None |
 

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -57,7 +57,7 @@ comments:
     allowParamOnConstructorProperties: false
   UndocumentedPublicClass:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/jettyTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
     searchInNestedClass: true
     searchInInnerClass: true
     searchInInnerObject: true
@@ -66,11 +66,11 @@ comments:
     ignoreDefaultCompanionObject: true
   UndocumentedPublicFunction:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/jettyTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
     searchProtectedFunction: false
   UndocumentedPublicProperty:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/jettyTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
     searchProtectedProperty: false
     ignoreEnumEntries: true
 
@@ -660,7 +660,7 @@ style:
     ignoreUsageInGenerics: false
   FunctionOnlyReturningConstant:
     active: true
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**', '**/jettyTest/**']
+    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
     ignoreOverridableFunction: true
     ignoreActualFunction: true
     excludedFunctions: []

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,7 +29,7 @@ flowchart TB
 | `tomcat-webflux` | Tomcat | WebFlux | 32 | Reactive endpoint coverage |
 | `jetty-webflux` | Jetty | WebFlux | 32 | Reactive endpoint coverage |
 
-**Total: 139 active tests** (4 TeeFilter tests skipped on Jetty)
+**Total: 135 active tests** (139 total, 4 TeeFilter tests skipped on Jetty)
 
 ## Common Module
 


### PR DESCRIPTION
## Summary

- Fix active test count in examples/README.md: "139 active tests" was incorrect — actual count is 135 active (139 total, 4 TeeFilter tests skipped on Jetty)
- Unify `local-port-strategy` property values to lowercase (`server`/`local`) in README.md to match docs/guide/configuration.md
- Remove obsolete `**/jettyTest/**` exclusion pattern from 4 locations in detekt.yml (directory no longer exists)

## Test Plan

- [x] `./gradlew clean build` passes
- [x] No functional code changes — documentation and static analysis config only