### PR TITLE
docs: quote Mermaid slash label and deduplicate content-type list

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Reference the captured bodies with `%requestContent` and `%responseContent`.
 | `logback.access.tee-filter.include-hosts` | Comma-separated host names that activate the filter. | All hosts |
 | `logback.access.tee-filter.exclude-hosts` | Comma-separated host names that bypass the filter. | None |
 | `logback.access.tee-filter.max-payload-size` | Maximum payload size in bytes that appears in log output. Larger bodies are replaced with a sentinel. | `65536` |
-| `logback.access.tee-filter.allowed-content-types` | Content-Type patterns allowed for body capture. When set, this list completely replaces the built-in defaults. | `text/*`, `application/json`, `application/xml`, `application/*+json`, `application/*+xml`, `application/x-www-form-urlencoded` |
+| `logback.access.tee-filter.allowed-content-types` | Content-Type patterns allowed for body capture. When set, this list completely replaces the built-in defaults. | Text, JSON, XML, and form-urlencoded types ([details](https://seijikohara.github.io/logback-access-spring-boot-starter/guide/advanced#teefilter)) |
 
 > **Security Warning**: Captured bodies can contain credentials, tokens, and personally identifiable information. Restrict the capture scope with `include-hosts` / `exclude-hosts`, and apply masking before the data leaves the host.
 >

--- a/docs/index.md
+++ b/docs/index.md
@@ -60,7 +60,7 @@ flowchart TB
     F --> G[Appenders]
     G -->|Console| H[Console Output]
     G -->|File| I[File Output]
-    G -->|JSON| J[Logstash/ELK]
+    G -->|JSON| J["Logstash/ELK"]
 
     subgraph optional["Optional Integrations"]
         K[Spring Security] -.->|Request Attribute| E

--- a/docs/ja/index.md
+++ b/docs/ja/index.md
@@ -60,7 +60,7 @@ flowchart TB
     F --> G[Appenders]
     G -->|Console| H[コンソール出力]
     G -->|File| I[ファイル出力]
-    G -->|JSON| J[Logstash/ELK]
+    G -->|JSON| J["Logstash/ELK"]
 
     subgraph optional["オプション連携"]
         K[Spring Security] -.->|リクエスト属性| E


### PR DESCRIPTION
Closes #138

- Quote `J["Logstash/ELK"]` in `docs/index.md` and `docs/ja/index.md` (Mermaid rule compliance + parity with README).
- Replace README's inline content-type enumeration with a short phrase + link to the canonical list in the advanced guide.