### PR TITLE
build: pin the Gradle wrapper distribution checksum

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 retries=0


### PR DESCRIPTION
Closes #133

Adds `distributionSha256Sum` (official SHA-256 for gradle-9.5.1-bin.zip) to `gradle-wrapper.properties`. URL validation alone does not verify archive integrity; this pins it for supply-chain hardening. Renovate / `gradle wrapper` will maintain it on upgrades.