### PR TITLE
chore: disable Renovate auto-merge for major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["major"],
-      "automerge": true
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
Closes #142

Sets the `major` packageRule to `automerge: false` so major dependency upgrades require manual review (minor/patch stay auto-merged via the top-level setting). Avoids auto-shipping breaking changes from a published library.