### PR TITLE
fix(tomcat): guard access-event extraction against exceptions

### DIFF
--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValve.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValve.kt
@@ -42,14 +42,26 @@ internal class TomcatValve(
         response: Response,
     ): Unit = next.invoke(request, response)
 
+    /**
+     * Tomcat's [AccessLog] contract requires implementations to tolerate null or
+     * malformed request/response objects from early-rejected requests. Extraction
+     * runs before [LogbackAccessContext.emit] (which has its own guard), so wrap it
+     * here to ensure an extraction failure never escapes into the Tomcat engine.
+     */
+    @Suppress("TooGenericExceptionCaught")
     override fun log(
         request: Request,
         response: Response,
         time: Long,
-    ): Unit =
-        createAccessEventData(logbackAccessContext, request, response, requestAttributesEnabled, time)
-            .let(::LogbackAccessEvent)
-            .let(logbackAccessContext::emit)
+    ) {
+        try {
+            createAccessEventData(logbackAccessContext, request, response, requestAttributesEnabled, time)
+                .let(::LogbackAccessEvent)
+                .let(logbackAccessContext::emit)
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to capture Tomcat access event" }
+        }
+    }
 
     companion object {
         private val logger = KotlinLogging.logger {}

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValveSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValveSpec.kt
@@ -1,0 +1,25 @@
+package io.github.seijikohara.spring.boot.logback.access.tomcat
+
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.mockk.every
+import io.mockk.mockk
+import org.apache.catalina.connector.Request
+import org.apache.catalina.connector.Response
+
+class TomcatValveSpec :
+    FunSpec({
+        test("log does not propagate exceptions thrown while extracting access-event data") {
+            val context = mockk<LogbackAccessContext>(relaxed = true)
+            val request =
+                mockk<Request>(relaxed = true) {
+                    // Simulate a malformed/early-rejected request whose getters fail.
+                    every { method } throws RuntimeException("malformed request")
+                }
+            val response = mockk<Response>(relaxed = true)
+            val valve = TomcatValve(context)
+
+            shouldNotThrowAny { valve.log(request, response, 0L) }
+        }
+    })


### PR DESCRIPTION
Closes #121

Wraps `TomcatValve.log`'s extraction-and-emit pipeline in a `try/catch` so a failure while reading a malformed/early-rejected request's getters never escapes into the Tomcat engine (Tomcat's `AccessLog` contract requires null/malformed-robustness). Adds `TomcatValveSpec` verifying `log()` swallows extraction exceptions.