### PR TITLE
fix(jetty): null-safe remote fields and correct elapsedTime guard

### DIFF
--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/AccessEventData.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/AccessEventData.kt
@@ -26,10 +26,10 @@ public data class AccessEventData(
     val serverName: String?,
     /** Local port on which the request was received. */
     val localPort: Int,
-    /** IP address of the remote client. */
-    val remoteAddr: String,
-    /** Hostname of the remote client. On Jetty, this equals [remoteAddr] (no reverse DNS lookup). */
-    val remoteHost: String,
+    /** IP address of the remote client, or null when the remote address is unavailable. */
+    val remoteAddr: String?,
+    /** Hostname of the remote client, or null when unavailable. On Jetty, this equals [remoteAddr] (no reverse DNS lookup). */
+    val remoteHost: String?,
     /** Authenticated username, or null if not authenticated. */
     val remoteUser: String?,
     /** Protocol and version (e.g., "HTTP/1.1"). */

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessEvent.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessEvent.kt
@@ -56,9 +56,9 @@ public class LogbackAccessEvent
 
         override fun getLocalPort(): Int = data.localPort
 
-        override fun getRemoteAddr(): String = data.remoteAddr
+        override fun getRemoteAddr(): String = data.remoteAddr ?: NA
 
-        override fun getRemoteHost(): String = data.remoteHost
+        override fun getRemoteHost(): String = data.remoteHost ?: NA
 
         override fun getRemoteUser(): String = data.remoteUser ?: NA
 
@@ -78,6 +78,9 @@ public class LogbackAccessEvent
 
         override fun getRequestHeader(key: String): String = data.requestHeaderMap[key] ?: NA
 
+        // getCookies() (plural) is intentionally not overridden: IAccessEvent's default returns an
+        // empty list. The built-in %requestCookie{name} converter uses getCookie(key), which is
+        // backed by data.cookieMap, so the standard pattern is unaffected.
         override fun getCookie(key: String): String = data.cookieMap[key] ?: NA
 
         override fun getRequestParameterMap(): Map<String, Array<String>> = parameterArrayMap()

--- a/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessEventSpec.kt
+++ b/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessEventSpec.kt
@@ -55,6 +55,16 @@ class LogbackAccessEventSpec :
             }
         }
 
+        test("returns NA when remoteAddr and remoteHost are null") {
+            val data = TestAccessEventDataFactory.createMinimalData().copy(remoteAddr = null, remoteHost = null)
+            val event = LogbackAccessEvent(data)
+
+            assertSoftly {
+                event.remoteAddr shouldBe NA
+                event.remoteHost shouldBe NA
+            }
+        }
+
         test("returns SENTINEL for null numeric fields") {
             val data = TestAccessEventDataFactory.createMinimalData()
             val event = LogbackAccessEvent(data)

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/jetty/JettyConfiguration.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/jetty/JettyConfiguration.kt
@@ -13,6 +13,10 @@ import org.springframework.context.annotation.Configuration
 
 /**
  * Registers Jetty-specific access logging infrastructure.
+ *
+ * The customizer assigns the [JettyRequestLog] to Jetty's single [org.eclipse.jetty.server.Server.setRequestLog]
+ * slot, so the starter takes ownership of the Jetty request log. Supply your own
+ * `logbackAccessJettyCustomizer` bean to override this behavior.
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(Server::class, ConfigurableJettyWebServerFactory::class)

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/jetty/JettyEventSource.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/jetty/JettyEventSource.kt
@@ -25,7 +25,10 @@ internal fun createAccessEventData(
 ): AccessEventData =
     AccessEventData(
         timeStamp = System.currentTimeMillis(),
-        elapsedTime = request.beginNanoTime.takeIf { it > 0 }?.let { NANOSECONDS.toMillis(System.nanoTime() - it) },
+        // beginNanoTime is a raw System.nanoTime() reading, which may legitimately be negative or
+        // zero. A valid request always has it set by the time RequestLog.log fires, so compute the
+        // duration directly rather than treating the raw clock value as a positivity flag.
+        elapsedTime = NANOSECONDS.toMillis(System.nanoTime() - request.beginNanoTime).coerceAtLeast(0),
         sequenceNumber = context.accessContext.sequenceNumberGenerator?.nextSequenceNumber(),
         threadName = Thread.currentThread().name,
         serverName = Request.getServerName(request),


### PR DESCRIPTION
Closes #122

- Make `AccessEventData.remoteAddr`/`remoteHost` nullable and map them to `NA` in `LogbackAccessEvent` (consistent with `serverName`), removing a latent NPE when the Jetty remote address is null.
- Compute `elapsedTime` from the duration (`now - beginNanoTime`) instead of guarding the raw clock value, which could discard valid timings.
- Document that `JettyConfiguration` owns the single Jetty `RequestLog` slot and that `getCookies()` (plural) is intentionally not overridden.

`apiCheck` confirms the nullability change does not alter the published `.api`. Adds a null-mapping test to `LogbackAccessEventSpec`.