### PR TITLE
fix(core): align <springProperty> missing-value handling with Spring Boot

### DIFF
--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/joran/SpringPropertySupport.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/joran/SpringPropertySupport.kt
@@ -60,7 +60,13 @@ internal class SpringPropertyModelHandler(
                 }
 
                 else -> {
-                    setProperty(ic, name, environment.getProperty(source, m.defaultValue.orEmpty()), stringToScope(m.scope))
+                    // Use defaultValue only when provided. When the source key is absent and no defaultValue is
+                    // given, getProperty(source) returns null and setProperty leaves the property undefined
+                    // (matching Spring Boot's SpringPropertyModelHandler), preserving Logback's ${name:-fallback}
+                    // substitution instead of forcing an empty string.
+                    val default = m.defaultValue
+                    val value = if (default != null) environment.getProperty(source, default) else environment.getProperty(source)
+                    setProperty(ic, name, value, stringToScope(m.scope))
                 }
             }
         }

--- a/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/joran/AccessJoranConfiguratorSpec.kt
+++ b/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/joran/AccessJoranConfiguratorSpec.kt
@@ -60,7 +60,7 @@ class AccessJoranConfiguratorSpec :
                 context.getProperty("myProp") shouldBe "fallback"
             }
 
-            test("uses empty string when property not found and no defaultValue") {
+            test("leaves the property undefined when not found and no defaultValue") {
                 val environment = MockEnvironment()
                 val context = AccessContext()
                 val configurator = AccessJoranConfigurator(environment)
@@ -78,7 +78,7 @@ class AccessJoranConfiguratorSpec :
 
                 configurator.doConfigure(ByteArrayInputStream(xml.toByteArray()))
 
-                context.getProperty("myProp") shouldBe ""
+                context.getProperty("myProp").shouldBeNull()
             }
         }
 


### PR DESCRIPTION
Closes #123

When a `<springProperty>` source key is absent and no `defaultValue` is given, the property is now left undefined (matching Spring Boot's `SpringPropertyModelHandler`) instead of being set to an empty string, preserving Logback's `${name:-fallback}` substitution. Updates the joran spec to assert the property is undefined.