### PR TITLE
ci: add concurrency control and tighten triggers/permissions

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-
 jobs:
   dependency-submission:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      # Required by the Dependency Submission API to submit the dependency graph.
+      contents: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,11 @@ permissions:
   id-token: write
   attestations: write
 
+# Never run two releases concurrently, but do not cancel an in-flight release.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 env:
   JAVA_VERSION: '21'
   JAVA_DISTRIBUTION: 'temurin'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,16 @@ name: Test
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 permissions:
   contents: read
+
+# Validate each PR commit once via pull_request, and cancel superseded runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
Closes #136

- `test.yml`: scope `push` to `main` (PR commits validated once via `pull_request`) + add a cancel-in-progress concurrency group.
- `release.yml`: add a non-cancelling `release` concurrency group.
- `dependency-submission.yml`: move `contents: write` to the job that needs it (least privilege).