### PR TITLE
refactor(core)!: make requestParameterArrayMap internal

### DIFF
--- a/logback-access-spring-boot-starter-core/api/logback-access-spring-boot-starter-core.api
+++ b/logback-access-spring-boot-starter-core/api/logback-access-spring-boot-starter-core.api
@@ -42,7 +42,6 @@ public final class io/github/seijikohara/spring/boot/logback/access/AccessEventD
 	public final fun getRemoteUser ()Ljava/lang/String;
 	public final fun getRequestContent ()Ljava/lang/String;
 	public final fun getRequestHeaderMap ()Ljava/util/Map;
-	public final fun getRequestParameterArrayMap ()Ljava/util/Map;
 	public final fun getRequestParameterMap ()Ljava/util/Map;
 	public final fun getRequestURI ()Ljava/lang/String;
 	public final fun getRequestURL ()Ljava/lang/String;

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/AccessEventData.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/AccessEventData.kt
@@ -66,8 +66,10 @@ public data class AccessEventData(
     /**
      * Array-backed parameter map for [ch.qos.logback.access.common.spi.IAccessEvent] compatibility.
      * Computed on each access from [requestParameterMap] to ensure correct behavior after deserialization.
+     * Internal: this is an implementation shim consumed only by [LogbackAccessEvent]; external callers
+     * should use the immutable, list-valued [requestParameterMap] instead.
      */
-    val requestParameterArrayMap: Map<String, Array<String>>
+    internal val requestParameterArrayMap: Map<String, Array<String>>
         get() = requestParameterMap.mapValues { (_, values) -> values.toTypedArray() }
 
     public companion object {


### PR DESCRIPTION
Closes #124

Marks `AccessEventData.requestParameterArrayMap` `internal` (it is an `IAccessEvent`-compat shim consumed only by `LogbackAccessEvent` in the same module) and regenerates the core `.api`.

**BREAKING CHANGE**: `getRequestParameterArrayMap()` is removed from the public API; use the immutable list-valued `requestParameterMap` instead.