### PR TITLE
build(core)!: demote kotlin-reflect from api to implementation

### DIFF
--- a/logback-access-spring-boot-starter-core/build.gradle.kts
+++ b/logback-access-spring-boot-starter-core/build.gradle.kts
@@ -18,10 +18,12 @@ mavenPublishing {
 dependencies {
     api(platform(libs.spring.boot.dependencies))
     api(libs.logback.access.common)
-    api(libs.kotlin.reflect)
 
     implementation(libs.spring.boot.starter)
     implementation(libs.kotlin.logging)
+    // Runtime requirement for Spring Boot constructor binding of the @ConfigurationProperties
+    // data class. Not part of the public compile surface, so it is not an api dependency.
+    implementation(libs.kotlin.reflect)
 }
 
 kotlin {


### PR DESCRIPTION
Closes #125

kotlin-reflect appears in no public `.api` type and is only a runtime requirement for Spring Boot constructor binding of the `@ConfigurationProperties` data class. Demote `api` -> `implementation` to stop widening consumers' compile classpaths. Verified runtime binding still works via the tomcat-mvc example test.

**BREAKING CHANGE**: kotlin-reflect is no longer exposed transitively on the consumer compile classpath (still present at runtime).