### PR TITLE
build: enforce binary-compatibility-validator on the published starter module

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -52,7 +52,7 @@ Refer to these files instead of reproducing their content here.
 
 - Version is derived from Git tags by `axion-release-plugin` (tag `v1.2.0` → version `1.2.0`).
 - Published to Maven Central via `gradle-maven-publish-plugin` with GPG signing.
-- Public API compatibility is enforced by `binary-compatibility-validator` (`.api` files in the core module).
+- Public API compatibility is enforced by `binary-compatibility-validator` (`.api` files in the core and starter modules).
 - SBOM is produced by the CycloneDX Gradle plugin.
 
 ## CI/CD

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,9 @@ plugins {
 }
 
 apiValidation {
+    // The published starter module is tracked so its public surface (the auto-configuration
+    // entry point and the deprecated compatibility alias) is enforced against drift.
     ignoredProjects += listOf(
-        "logback-access-spring-boot-starter",
         "common",
         "tomcat-mvc",
         "jetty-mvc",

--- a/logback-access-spring-boot-starter/api/logback-access-spring-boot-starter.api
+++ b/logback-access-spring-boot-starter/api/logback-access-spring-boot-starter.api
@@ -1,0 +1,9 @@
+public final class io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessAutoConfiguration {
+	public static final field Companion Lio/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessAutoConfiguration$Companion;
+	public fun <init> ()V
+	public final fun logbackAccessContext (Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessProperties;Lorg/springframework/core/io/ResourceLoader;Lorg/springframework/core/env/Environment;)Lio/github/seijikohara/spring/boot/logback/access/LogbackAccessContext;
+}
+
+public final class io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessAutoConfiguration$Companion {
+}
+


### PR DESCRIPTION
Closes #126

Removes `logback-access-spring-boot-starter` from `apiValidation.ignoredProjects` and commits its `.api` baseline, so `apiCheck` now guards the starter's public auto-configuration entry point against drift. Updates CLAUDE.md accordingly.

Note: the deprecated root-package `LogbackAccessAutoConfiguration` typealias is a compile-time construct not represented in `.api`; its backward compatibility is guarded by a dedicated test (#129).