### PR TITLE
test(starter): cover deprecated auto-config alias and .replacements remap

### DIFF
--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/DeprecatedAutoConfigurationAliasSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/DeprecatedAutoConfigurationAliasSpec.kt
@@ -1,0 +1,31 @@
+package io.github.seijikohara.spring.boot.logback.access
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.github.seijikohara.spring.boot.logback.access.autoconfigure.LogbackAccessAutoConfiguration as AutoConfig
+
+/**
+ * Guards the backward-compatibility surface kept for consumers that referenced the pre-rename
+ * auto-configuration. Both the deprecated typealias and the `.replacements` remap must keep
+ * pointing at the current autoconfigure class until they are intentionally removed in v2.0.0.
+ */
+class DeprecatedAutoConfigurationAliasSpec :
+    FunSpec({
+        test("deprecated root-package alias resolves to the autoconfigure class") {
+            @Suppress("DEPRECATION")
+            LogbackAccessAutoConfiguration::class.java shouldBe AutoConfig::class.java
+        }
+
+        test(".replacements remaps the old FQN to the autoconfigure class") {
+            val replacements =
+                DeprecatedAutoConfigurationAliasSpec::class.java
+                    .getResource("/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.replacements")
+                    ?.readText()
+                    .orEmpty()
+
+            replacements shouldContain
+                "io.github.seijikohara.spring.boot.logback.access.LogbackAccessAutoConfiguration=" +
+                "io.github.seijikohara.spring.boot.logback.access.autoconfigure.LogbackAccessAutoConfiguration"
+        }
+    })


### PR DESCRIPTION
Closes #129

Adds `DeprecatedAutoConfigurationAliasSpec` asserting (1) the deprecated root-package `LogbackAccessAutoConfiguration` typealias still resolves to the autoconfigure class, and (2) the `.replacements` file remaps the old FQN to the new one. Guards the backward-compatibility surface against accidental removal before v2.0.0.