### PR TITLE
test(examples): fix data race in access-event test utilities

### DIFF
--- a/examples/common/src/main/java/examples/AbstractBasicAccessLogTest.java
+++ b/examples/common/src/main/java/examples/AbstractBasicAccessLogTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractBasicAccessLogTest {
     @BeforeEach
     void setUpAppender() {
         listAppender = AccessEventTestUtils.getListAppender(getLogbackAccessContext(), "list");
-        listAppender.list.clear();
+        AccessEventTestUtils.reset(listAppender);
     }
 
     protected ListAppender<IAccessEvent> getListAppender() {

--- a/examples/common/src/main/java/examples/AbstractSecurityTest.java
+++ b/examples/common/src/main/java/examples/AbstractSecurityTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractSecurityTest {
     @BeforeEach
     void setUpAppender() {
         listAppender = AccessEventTestUtils.getListAppender(getLogbackAccessContext(), "list");
-        listAppender.list.clear();
+        AccessEventTestUtils.reset(listAppender);
     }
 
     protected ListAppender<IAccessEvent> getListAppender() {

--- a/examples/common/src/main/java/examples/AccessEventTestUtils.java
+++ b/examples/common/src/main/java/examples/AccessEventTestUtils.java
@@ -9,11 +9,19 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Utility class for testing access events.
+ *
+ * <p>{@link ListAppender#list} is a plain {@link java.util.ArrayList} mutated by logback's
+ * {@code AppenderBase.doAppend}, which holds the appender's intrinsic monitor. Server worker threads
+ * emit access events after the HTTP response returns, so they can mutate the list while a test thread
+ * reads it. All access to {@code appender.list} here is therefore guarded by {@code synchronized
+ * (appender)} to use the same monitor and avoid {@link java.util.ConcurrentModificationException} and
+ * stale reads.
  */
 public final class AccessEventTestUtils {
 
     private static final long DEFAULT_TIMEOUT_MS = 5000L;
     private static final long POLL_INTERVAL_MS = 50L;
+    private static final long QUIESCENCE_MS = 200L;
 
     private AccessEventTestUtils() {
     }
@@ -30,6 +38,17 @@ public final class AccessEventTestUtils {
             final LogbackAccessContext context,
             final String appenderName) {
         return (ListAppender<IAccessEvent>) context.getAccessContext().getAppender(appenderName);
+    }
+
+    /**
+     * Clears the appender under its own monitor, so the reset does not race with a concurrent emit.
+     *
+     * @param appender the ListAppender to reset
+     */
+    public static void reset(final ListAppender<IAccessEvent> appender) {
+        synchronized (appender) {
+            appender.list.clear();
+        }
     }
 
     /**
@@ -56,6 +75,9 @@ public final class AccessEventTestUtils {
     /**
      * Waits for the specified number of access events to be logged with a custom timeout.
      *
+     * <p>Once {@code count} events are observed, the method waits a short quiescence period and
+     * re-snapshots, so a caller asserting an exact size can detect a late duplicate or spurious event.
+     *
      * @param appender  the ListAppender to wait on
      * @param count     the number of events to wait for
      * @param timeoutMs the timeout in milliseconds
@@ -66,18 +88,18 @@ public final class AccessEventTestUtils {
             final int count,
             final long timeoutMs) {
         final var deadline = System.currentTimeMillis() + timeoutMs;
-        while (System.currentTimeMillis() < deadline) {
-            if (appender.list.size() >= count) {
-                return List.copyOf(appender.list);
-            }
-            try {
-                TimeUnit.MILLISECONDS.sleep(POLL_INTERVAL_MS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+        var snapshot = snapshot(appender);
+        while (snapshot.size() < count && System.currentTimeMillis() < deadline) {
+            if (!sleep(POLL_INTERVAL_MS)) {
                 break;
             }
+            snapshot = snapshot(appender);
         }
-        return List.copyOf(appender.list);
+        if (snapshot.size() >= count) {
+            sleep(QUIESCENCE_MS);
+            snapshot = snapshot(appender);
+        }
+        return snapshot;
     }
 
     /**
@@ -98,14 +120,26 @@ public final class AccessEventTestUtils {
     public static void awaitNoEvents(
             final ListAppender<IAccessEvent> appender,
             final long timeoutMs) {
+        sleep(timeoutMs);
+        final var snapshot = snapshot(appender);
+        if (!snapshot.isEmpty()) {
+            throw new AssertionError("Expected no events but found " + snapshot.size());
+        }
+    }
+
+    private static List<IAccessEvent> snapshot(final ListAppender<IAccessEvent> appender) {
+        synchronized (appender) {
+            return List.copyOf(appender.list);
+        }
+    }
+
+    private static boolean sleep(final long millis) {
         try {
-            TimeUnit.MILLISECONDS.sleep(timeoutMs);
+            TimeUnit.MILLISECONDS.sleep(millis);
+            return true;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-        }
-        if (!appender.list.isEmpty()) {
-            throw new AssertionError(
-                    "Expected no events but found " + appender.list.size());
+            return false;
         }
     }
 }

--- a/examples/common/src/main/java/examples/test/common/AbstractJsonLoggingTest.java
+++ b/examples/common/src/main/java/examples/test/common/AbstractJsonLoggingTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractJsonLoggingTest {
     @BeforeEach
     void setUpJsonLoggingAppender() {
         listAppender = AccessEventTestUtils.getListAppender(getLogbackAccessContext(), "list");
-        listAppender.list.clear();
+        AccessEventTestUtils.reset(listAppender);
     }
 
     protected ListAppender<IAccessEvent> getListAppender() {

--- a/examples/common/src/main/java/examples/test/mvc/AbstractLocalPortStrategyTest.java
+++ b/examples/common/src/main/java/examples/test/mvc/AbstractLocalPortStrategyTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractLocalPortStrategyTest {
     @BeforeEach
     void setUpLocalPortAppender() {
         listAppender = AccessEventTestUtils.getListAppender(getLogbackAccessContext(), "list");
-        listAppender.list.clear();
+        AccessEventTestUtils.reset(listAppender);
     }
 
     protected ListAppender<IAccessEvent> getListAppender() {

--- a/examples/common/src/main/java/examples/test/mvc/AbstractTeeFilterTest.java
+++ b/examples/common/src/main/java/examples/test/mvc/AbstractTeeFilterTest.java
@@ -41,7 +41,7 @@ public abstract class AbstractTeeFilterTest {
     @BeforeEach
     void setUpTeeFilterAppender() {
         listAppender = AccessEventTestUtils.getListAppender(getLogbackAccessContext(), "list");
-        listAppender.list.clear();
+        AccessEventTestUtils.reset(listAppender);
     }
 
     protected ListAppender<IAccessEvent> getListAppender() {

--- a/examples/common/src/main/java/examples/test/webflux/AbstractReactiveAccessLogTest.java
+++ b/examples/common/src/main/java/examples/test/webflux/AbstractReactiveAccessLogTest.java
@@ -38,7 +38,7 @@ public abstract class AbstractReactiveAccessLogTest {
     @BeforeEach
     void setUpReactiveAppender() {
         listAppender = AccessEventTestUtils.getListAppender(getLogbackAccessContext(), "list");
-        listAppender.list.clear();
+        AccessEventTestUtils.reset(listAppender);
     }
 
     protected ListAppender<IAccessEvent> getListAppender() {

--- a/examples/common/src/main/java/examples/test/webflux/AbstractReactiveLocalPortStrategyTest.java
+++ b/examples/common/src/main/java/examples/test/webflux/AbstractReactiveLocalPortStrategyTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractReactiveLocalPortStrategyTest {
     @BeforeEach
     void setUpLocalPortAppender() {
         listAppender = AccessEventTestUtils.getListAppender(getLogbackAccessContext(), "list");
-        listAppender.list.clear();
+        AccessEventTestUtils.reset(listAppender);
     }
 
     /**

--- a/examples/common/src/main/java/examples/test/webflux/AbstractRouterFunctionTest.java
+++ b/examples/common/src/main/java/examples/test/webflux/AbstractRouterFunctionTest.java
@@ -38,7 +38,7 @@ public abstract class AbstractRouterFunctionTest {
     @BeforeEach
     void setUpRouterFunctionAppender() {
         listAppender = AccessEventTestUtils.getListAppender(getLogbackAccessContext(), "list");
-        listAppender.list.clear();
+        AccessEventTestUtils.reset(listAppender);
     }
 
     protected ListAppender<IAccessEvent> getListAppender() {


### PR DESCRIPTION
Closes #130

- Guard all `ListAppender.list` access in `AccessEventTestUtils` with `synchronized (appender)` (same monitor as logback's `AppenderBase.doAppend`), eliminating the CME / stale-read hazard.
- Add `reset(appender)` and replace the eight unguarded `listAppender.list.clear()` calls in the abstract base classes.
- Add a quiescence re-snapshot in `awaitEvents` so `hasSize(n)` can detect a late duplicate/spurious event.

Verified against servlet (BasicAccessLog, UrlFiltering) and reactive (ReactiveAccessLog) example tests.

Follow-ups (assertion quality, tracked separately): capturing/parsing the LogstashAccessEncoder JSON output (folded into the example-config consolidation #143) and distinguishing the LOCAL vs SERVER port strategy with a divergent `Host` header (needs JDK restricted-header support).