### PR TITLE
build(core): generate spring-configuration-metadata for logback.access.*

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ logback-access-common = { module = "ch.qos.logback.access:logback-access-common"
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstash-logback-encoder" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 nullaway = { module = "com.uber.nullaway:nullaway", version.ref = "nullaway" }
+spring-boot-configuration-processor = { module = "org.springframework.boot:spring-boot-configuration-processor" }
 spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter" }
 spring-boot-starter-jetty = { module = "org.springframework.boot:spring-boot-starter-jetty" }

--- a/logback-access-spring-boot-starter-core/build.gradle.kts
+++ b/logback-access-spring-boot-starter-core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("maven-publish-conventions")
+    id("org.jetbrains.kotlin.kapt")
     alias(libs.plugins.detekt)
     alias(libs.plugins.spotless)
     `java-library`
@@ -24,6 +25,13 @@ dependencies {
     // Runtime requirement for Spring Boot constructor binding of the @ConfigurationProperties
     // data class. Not part of the public compile surface, so it is not an api dependency.
     implementation(libs.kotlin.reflect)
+
+    // Generates META-INF/spring-configuration-metadata.json for logback.access.* so consumers get
+    // IDE auto-completion and property documentation. The Spring Boot configuration processor is a
+    // Java annotation processor, so it runs through kapt for this Kotlin module. The kapt
+    // configuration needs the BOM applied directly to resolve the processor version.
+    kapt(platform(libs.spring.boot.dependencies))
+    kapt(libs.spring.boot.configuration.processor)
 }
 
 kotlin {


### PR DESCRIPTION
Closes #131

Wires the Spring Boot configuration processor through kapt on the core module so `META-INF/spring-configuration-metadata.json` is generated for all `logback.access.*` properties (groups: `logback.access`, `.filter`, `.tee-filter`, `.tomcat`), giving consumers IDE auto-completion, type hints, and descriptions. Verified the metadata ships in the core jar's META-INF.

The `kapt` configuration needs the Spring Boot BOM applied directly to resolve the processor version.