### PR TITLE
test(starter): guard the servlet-only gating of security and TeeFilter

### DIFF
--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessAutoConfigurationSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessAutoConfigurationSpec.kt
@@ -198,13 +198,18 @@ class LogbackAccessAutoConfigurationSpec :
                     }
             }
 
-            test("does not create security filter in reactive web context") {
+            test("does not create servlet-only filters in reactive web context") {
                 ReactiveWebApplicationContextRunner()
                     .withConfiguration(autoConfiguration)
                     .withPropertyValues(
                         "logback.access.config-location=${LogbackAccessProperties.FALLBACK_CONFIG}",
+                        // Enabled, yet still must not register under WebFlux because both beans are
+                        // gated by @ConditionalOnWebApplication(type = SERVLET). This locks in the
+                        // documented Servlet-only contract: reactive access logs always render %u as "-".
+                        "logback.access.tee-filter.enabled=true",
                     ).run { context ->
                         assertThat(context).doesNotHaveBean("logbackAccessSecurityFilter")
+                        assertThat(context).doesNotHaveBean("logbackAccessTeeFilter")
                     }
             }
         }


### PR DESCRIPTION
Closes #144

Extends the reactive-web-context test in `LogbackAccessAutoConfigurationSpec` to assert that neither `logbackAccessSecurityFilter` nor `logbackAccessTeeFilter` is registered under WebFlux (even with `tee-filter.enabled=true`), locking in the documented Servlet-only contract for `%u` and body capture. The reactive `%u` limitation is already documented in the advanced guide (`%u` always renders as `-` under WebFlux).