### PR TITLE
feat: add GraalVM native-image RuntimeHints for AOT support

### DIFF
--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessAutoConfiguration.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessAutoConfiguration.kt
@@ -14,6 +14,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.ImportRuntimeHints
 import org.springframework.core.env.Environment
 import org.springframework.core.io.ResourceLoader
 
@@ -40,6 +41,7 @@ import org.springframework.core.io.ResourceLoader
     SecurityConfiguration::class,
     TeeFilterConfiguration::class,
 )
+@ImportRuntimeHints(LogbackAccessRuntimeHints::class)
 class LogbackAccessAutoConfiguration {
     /** Creates the [LogbackAccessContext] bean that manages the Logback-access lifecycle. */
     @Bean

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessRuntimeHints.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessRuntimeHints.kt
@@ -1,0 +1,48 @@
+package io.github.seijikohara.spring.boot.logback.access.autoconfigure
+
+import org.springframework.aot.hint.MemberCategory
+import org.springframework.aot.hint.RuntimeHints
+import org.springframework.aot.hint.RuntimeHintsRegistrar
+import org.springframework.aot.hint.TypeReference
+
+/**
+ * Registers GraalVM native-image hints for the reflective and resource access paths used by the
+ * Joran-based access-log configuration, so the starter works under AOT / native compilation.
+ *
+ * The Joran model, action, and handler classes are referenced by type during rule registration and
+ * model processing, and the bundled fallback configuration is loaded as a classpath resource. Types
+ * are registered by name because the Joran extension types are `internal` to the core module.
+ */
+internal class LogbackAccessRuntimeHints : RuntimeHintsRegistrar {
+    override fun registerHints(
+        hints: RuntimeHints,
+        classLoader: ClassLoader?,
+    ) {
+        JORAN_TYPES.forEach { type ->
+            hints.reflection().registerType(
+                TypeReference.of(type),
+                MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+                MemberCategory.INVOKE_PUBLIC_METHODS,
+            )
+        }
+        hints.resources().registerPattern(FALLBACK_CONFIG_RESOURCE)
+    }
+
+    private companion object {
+        private const val JORAN_PACKAGE = "io.github.seijikohara.spring.boot.logback.access.joran"
+
+        private val JORAN_TYPES =
+            listOf(
+                "$JORAN_PACKAGE.AccessJoranConfigurator",
+                "$JORAN_PACKAGE.SpringPropertyAction",
+                "$JORAN_PACKAGE.SpringPropertyModel",
+                "$JORAN_PACKAGE.SpringPropertyModelHandler",
+                "$JORAN_PACKAGE.SpringProfileAction",
+                "$JORAN_PACKAGE.SpringProfileModel",
+                "$JORAN_PACKAGE.SpringProfileModelHandler",
+            )
+
+        private const val FALLBACK_CONFIG_RESOURCE =
+            "io/github/seijikohara/spring/boot/logback/access/logback-access-spring.xml"
+    }
+}

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessRuntimeHintsSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/autoconfigure/LogbackAccessRuntimeHintsSpec.kt
@@ -1,0 +1,26 @@
+package io.github.seijikohara.spring.boot.logback.access.autoconfigure
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.aot.hint.RuntimeHints
+import org.springframework.aot.hint.TypeReference
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates
+
+class LogbackAccessRuntimeHintsSpec :
+    FunSpec({
+        val hints = RuntimeHints().also { LogbackAccessRuntimeHints().registerHints(it, javaClass.classLoader) }
+
+        test("registers reflection hints for the Joran springProperty types") {
+            RuntimeHintsPredicates
+                .reflection()
+                .onType(TypeReference.of("io.github.seijikohara.spring.boot.logback.access.joran.SpringPropertyModel"))
+                .test(hints) shouldBe true
+        }
+
+        test("registers a resource hint for the bundled fallback configuration") {
+            RuntimeHintsPredicates
+                .resource()
+                .forResource("io/github/seijikohara/spring/boot/logback/access/logback-access-spring.xml")
+                .test(hints) shouldBe true
+        }
+    })


### PR DESCRIPTION
Closes #145

Adds `LogbackAccessRuntimeHints` (wired via `@ImportRuntimeHints` on the auto-configuration) registering reflection hints for the Joran `springProperty`/`springProfile` action/model/handler types and a resource hint for the bundled fallback configuration. Types are registered by name because the Joran extension types are `internal` to the core module. A `RuntimeHintsPredicates`-based test verifies the registrations. Hints are additive and harmless on the JVM; native verification is a follow-up (no native CI yet).