### PR TITLE
test(starter): add Tomcat and Jetty event-source unit tests

### DIFF
--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/jetty/JettyEventSourceSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/jetty/JettyEventSourceSpec.kt
@@ -1,0 +1,86 @@
+package io.github.seijikohara.spring.boot.logback.access.jetty
+
+import ch.qos.logback.access.common.spi.AccessContext
+import ch.qos.logback.core.spi.SequenceNumberGenerator
+import io.github.seijikohara.spring.boot.logback.access.LocalPortStrategy
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.eclipse.jetty.server.Request
+import org.eclipse.jetty.server.Response
+
+class JettyEventSourceSpec :
+    FunSpec({
+        fun properties(): LogbackAccessProperties =
+            LogbackAccessProperties(
+                enabled = true,
+                configLocation = null,
+                localPortStrategy = LocalPortStrategy.SERVER,
+                tomcat = LogbackAccessProperties.TomcatProperties(requestAttributesEnabled = null),
+                teeFilter = LogbackAccessProperties.TeeFilterProperties(false, null, null, 65536L, null),
+                filter = LogbackAccessProperties.FilterProperties(null, null),
+            )
+
+        fun context(generator: SequenceNumberGenerator? = null): LogbackAccessContext =
+            mockk {
+                every { properties } returns properties()
+                every { accessContext } returns
+                    mockk<AccessContext>(relaxed = true) {
+                        every { sequenceNumberGenerator } returns generator
+                    }
+            }
+
+        // Stubs the static Jetty accessors that createAccessEventData reaches for a minimal request.
+        fun stubStatics(
+            request: Request,
+            response: Response,
+            contentBytesWritten: Long = 0L,
+        ) {
+            every { Request.getServerName(request) } returns "localhost"
+            every { Request.getServerPort(request) } returns 8080
+            every { Request.getRemoteAddr(request) } returns "127.0.0.1"
+            every { Request.getCookies(request) } returns emptyList()
+            every { Response.getContentBytesWritten(response) } returns contentBytesWritten
+        }
+
+        test("swallows a session lookup exception and records a null session id") {
+            mockkStatic(Request::class, Response::class) {
+                val request =
+                    mockk<Request>(relaxed = true) {
+                        every { beginNanoTime } returns System.nanoTime()
+                        every { getSession(false) } throws IllegalStateException("session unavailable")
+                    }
+                val response = mockk<Response>(relaxed = true)
+                stubStatics(request, response)
+
+                val data = createAccessEventData(context(), request, response)
+
+                data.sessionID.shouldBeNull()
+            }
+        }
+
+        test("computes a non-negative elapsed time, null sequence number, and the written content length") {
+            mockkStatic(Request::class, Response::class) {
+                val request =
+                    mockk<Request>(relaxed = true) {
+                        every { beginNanoTime } returns System.nanoTime()
+                        every { getSession(false) } returns null
+                    }
+                val response = mockk<Response>(relaxed = true)
+                stubStatics(request, response, contentBytesWritten = 123L)
+
+                val data = createAccessEventData(context(generator = null), request, response)
+
+                data.sequenceNumber.shouldBeNull()
+                data.contentLength shouldBe 123L
+                data.elapsedTime.shouldNotBeNull().shouldBeGreaterThanOrEqual(0L)
+            }
+        }
+    })

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSourceSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSourceSpec.kt
@@ -1,0 +1,85 @@
+package io.github.seijikohara.spring.boot.logback.access.tomcat
+
+import ch.qos.logback.access.common.spi.AccessContext
+import ch.qos.logback.core.spi.SequenceNumberGenerator
+import io.github.seijikohara.spring.boot.logback.access.AccessEventData
+import io.github.seijikohara.spring.boot.logback.access.LocalPortStrategy
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.apache.catalina.connector.Request
+import org.apache.catalina.connector.Response
+
+class TomcatEventSourceSpec :
+    FunSpec({
+        fun properties(): LogbackAccessProperties =
+            LogbackAccessProperties(
+                enabled = true,
+                configLocation = null,
+                localPortStrategy = LocalPortStrategy.SERVER,
+                tomcat = LogbackAccessProperties.TomcatProperties(requestAttributesEnabled = null),
+                teeFilter = LogbackAccessProperties.TeeFilterProperties(false, null, null, 65536L, null),
+                filter = LogbackAccessProperties.FilterProperties(null, null),
+            )
+
+        fun context(generator: SequenceNumberGenerator? = null): LogbackAccessContext =
+            mockk {
+                every { properties } returns properties()
+                every { accessContext } returns
+                    mockk<AccessContext>(relaxed = true) {
+                        every { sequenceNumberGenerator } returns generator
+                    }
+            }
+
+        fun request(): Request =
+            mockk(relaxed = true) {
+                every { method } returns "GET"
+                every { requestURI } returns "/api/users"
+                every { queryString } returns null
+            }
+
+        fun response(): Response = mockk(relaxed = true) { every { status } returns 200 }
+
+        fun event(
+            elapsedTimeNanos: Long,
+            context: LogbackAccessContext = context(),
+            request: Request = request(),
+        ): AccessEventData =
+            createAccessEventData(context, request, response(), requestAttributesEnabled = false, elapsedTimeNanos = elapsedTimeNanos)
+
+        test("converts a non-negative elapsedTimeNanos to milliseconds") {
+            val data = event(elapsedTimeNanos = 5_000_000L)
+
+            data.elapsedTime shouldBe 5L
+            data.statusCode shouldBe 200
+        }
+
+        test("falls back to a non-negative elapsed time when elapsedTimeNanos is negative") {
+            val request = request()
+            every { request.coyoteRequest.startTime } returns System.currentTimeMillis()
+
+            val data = event(elapsedTimeNanos = -1L, request = request)
+
+            data.elapsedTime.shouldNotBeNull().shouldBeGreaterThanOrEqual(0L)
+        }
+
+        test("produces a null sequence number when no generator is configured") {
+            val data = event(elapsedTimeNanos = 0L, context = context(generator = null))
+
+            data.sequenceNumber.shouldBeNull()
+        }
+
+        test("uses the configured sequence number generator") {
+            val generator = mockk<SequenceNumberGenerator> { every { nextSequenceNumber() } returns 42L }
+
+            val data = event(elapsedTimeNanos = 0L, context = context(generator = generator))
+
+            data.sequenceNumber shouldBe 42L
+        }
+    })


### PR DESCRIPTION
Closes #127

Adds `TomcatEventSourceSpec` and `JettyEventSourceSpec` covering the previously-untested `createAccessEventData` branch logic: the Tomcat elapsed-time fallback and sequence-number generator path, and the Jetty session-id `try/catch` (exception swallowed to null), elapsed-time computation, content-length, and null sequence-number path (Jetty statics stubbed via `mockkStatic`).