### PR TITLE
test(examples): validate JSON output and distinguish the LOCAL port strategy

### DIFF
--- a/examples/common/src/main/java/examples/CapturingOutputStreamAppender.java
+++ b/examples/common/src/main/java/examples/CapturingOutputStreamAppender.java
@@ -1,0 +1,46 @@
+package examples;
+
+import ch.qos.logback.access.common.spi.IAccessEvent;
+import ch.qos.logback.core.OutputStreamAppender;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Test appender that captures its encoder's output (for example JSON) into memory, so tests can
+ * validate the encoded bytes rather than only the in-memory {@link IAccessEvent}.
+ *
+ * <p>{@link ByteArrayOutputStream} guards its own writes, and the read/reset methods synchronize on
+ * the same instance, so capture is safe across the appender's writer thread and the test thread.
+ */
+public final class CapturingOutputStreamAppender extends OutputStreamAppender<IAccessEvent> {
+
+    private final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+
+    @Override
+    public void start() {
+        setImmediateFlush(true);
+        setOutputStream(stream);
+        super.start();
+    }
+
+    /**
+     * Returns the encoded output captured so far, decoded as UTF-8.
+     *
+     * @return the captured output
+     */
+    public String getCapturedOutput() {
+        synchronized (stream) {
+            return stream.toString(StandardCharsets.UTF_8);
+        }
+    }
+
+    /**
+     * Clears the captured output.
+     */
+    public void resetCapture() {
+        synchronized (stream) {
+            stream.reset();
+        }
+    }
+}

--- a/examples/common/src/main/java/examples/HttpClientTestUtils.java
+++ b/examples/common/src/main/java/examples/HttpClientTestUtils.java
@@ -1,5 +1,7 @@
 package examples;
 
+import java.io.IOException;
+import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -30,6 +32,35 @@ public final class HttpClientTestUtils {
                 .GET()
                 .build();
         return CLIENT.send(request, BodyHandlers.ofString());
+    }
+
+    /**
+     * Sends a raw HTTP/1.1 GET with an explicit Host header.
+     *
+     * <p>The JDK HttpClient forbids overriding the restricted Host header, so this uses a plain
+     * socket to let tests exercise a Host that diverges from the actual connection (for example, to
+     * verify that the LOCAL port strategy ignores the Host header port).
+     *
+     * @param host       the TCP host to connect to
+     * @param port       the TCP port to connect to
+     * @param path       the request path (for example, "/api/hello")
+     * @param hostHeader the Host header value to send (for example, "example.invalid:1")
+     * @throws IOException if the request fails
+     */
+    public static void getWithHostHeader(
+            final String host,
+            final int port,
+            final String path,
+            final String hostHeader) throws IOException {
+        try (var socket = new Socket(host, port)) {
+            final var request = "GET " + path + " HTTP/1.1\r\n"
+                    + "Host: " + hostHeader + "\r\n"
+                    + "Connection: close\r\n\r\n";
+            socket.getOutputStream().write(request.getBytes(StandardCharsets.US_ASCII));
+            socket.getOutputStream().flush();
+            // Drain the response so the server completes the request and logs the access event.
+            socket.getInputStream().readAllBytes();
+        }
     }
 
     /**

--- a/examples/common/src/main/java/examples/test/common/AbstractJsonLoggingTest.java
+++ b/examples/common/src/main/java/examples/test/common/AbstractJsonLoggingTest.java
@@ -3,6 +3,7 @@ package examples.test.common;
 import ch.qos.logback.access.common.spi.IAccessEvent;
 import ch.qos.logback.core.read.ListAppender;
 import examples.AccessEventTestUtils;
+import examples.CapturingOutputStreamAppender;
 import examples.HttpClientTestUtils;
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
 import net.logstash.logback.encoder.LogstashAccessEncoder;
@@ -41,10 +42,15 @@ public abstract class AbstractJsonLoggingTest {
     void setUpJsonLoggingAppender() {
         listAppender = AccessEventTestUtils.getListAppender(getLogbackAccessContext(), "list");
         AccessEventTestUtils.reset(listAppender);
+        jsonCaptureAppender().resetCapture();
     }
 
     protected ListAppender<IAccessEvent> getListAppender() {
         return listAppender;
+    }
+
+    private CapturingOutputStreamAppender jsonCaptureAppender() {
+        return (CapturingOutputStreamAppender) getLogbackAccessContext().getAccessContext().getAppender("jsonCapture");
     }
 
     @Test
@@ -98,5 +104,22 @@ public abstract class AbstractJsonLoggingTest {
         assertThat(events).hasSize(1);
         final var event = events.get(0);
         assertThat(event.getQueryString()).isEqualTo("?name=JSON");
+    }
+
+    @Test
+    void jsonEncoderProducesStructuredJsonOutput() throws Exception {
+        HttpClientTestUtils.get(getBaseUrl() + "/api/hello");
+        AccessEventTestUtils.awaitEvents(listAppender);
+
+        final var output = jsonCaptureAppender().getCapturedOutput().strip();
+        final var lines = output.split("\\R");
+        final var json = lines[lines.length - 1].strip();
+
+        // The LogstashAccessEncoder must emit a single JSON object carrying the request fields.
+        assertThat(json).startsWith("{").endsWith("}");
+        assertThat(json).contains("\"method\"").contains("\"GET\"");
+        assertThat(json).contains("\"status_code\"").contains("200");
+        assertThat(json).contains("\"requested_uri\"").contains("/api/hello");
+        assertThat(json).contains("\"@timestamp\"");
     }
 }

--- a/examples/common/src/main/java/examples/test/mvc/AbstractLocalPortStrategyTest.java
+++ b/examples/common/src/main/java/examples/test/mvc/AbstractLocalPortStrategyTest.java
@@ -69,16 +69,16 @@ public abstract class AbstractLocalPortStrategyTest {
 
     @Test
     void localPortDoesNotChangeWithHostHeader() throws Exception {
-        // Even if the Host header specifies a different port,
-        // LOCAL strategy should still return the actual local port
-        HttpClientTestUtils.get(getBaseUrl() + "/api/hello");
+        // Send a Host header advertising a divergent port. The LOCAL strategy must still report the
+        // actual connection port, not the port from the Host header.
+        HttpClientTestUtils.getWithHostHeader("localhost", getPort(), "/api/hello", "example.invalid:1");
 
         final var events = AccessEventTestUtils.awaitEvents(listAppender);
 
         assertThat(events).hasSize(1);
         final var event = events.get(0);
         assertThat(event.getLocalPort())
-                .as("LOCAL strategy should return actual connection port, not Host header port")
+                .as("LOCAL strategy should return the actual connection port, not the Host header port")
                 .isEqualTo(getPort());
     }
 }

--- a/examples/common/src/main/java/examples/test/webflux/AbstractReactiveLocalPortStrategyTest.java
+++ b/examples/common/src/main/java/examples/test/webflux/AbstractReactiveLocalPortStrategyTest.java
@@ -75,16 +75,16 @@ public abstract class AbstractReactiveLocalPortStrategyTest {
 
     @Test
     void localPortDoesNotChangeWithHostHeader() throws Exception {
-        // Even if the Host header specifies a different port,
-        // LOCAL strategy should still return the actual local port
-        HttpClientTestUtils.get(getBaseUrl() + "/api/hello");
+        // Send a Host header advertising a divergent port. The LOCAL strategy must still report the
+        // actual connection port, not the port from the Host header.
+        HttpClientTestUtils.getWithHostHeader("localhost", getPort(), "/api/hello", "example.invalid:1");
 
         final var events = AccessEventTestUtils.awaitEvents(listAppender);
 
         assertThat(events).hasSize(1);
         final var event = events.get(0);
         assertThat(event.getLocalPort())
-                .as("LOCAL strategy should return actual connection port, not Host header port")
+                .as("LOCAL strategy should return the actual connection port, not the Host header port")
                 .isEqualTo(getPort());
     }
 }

--- a/examples/common/src/main/resources/logback-access-json.xml
+++ b/examples/common/src/main/resources/logback-access-json.xml
@@ -8,6 +8,12 @@
     <!-- ListAppender for test verification -->
     <appender name="list" class="ch.qos.logback.core.read.ListAppender"/>
 
+    <!-- Capturing appender so tests can validate the actual encoded JSON output -->
+    <appender name="jsonCapture" class="examples.CapturingOutputStreamAppender">
+        <encoder class="net.logstash.logback.encoder.LogstashAccessEncoder"/>
+    </appender>
+
     <appender-ref ref="jsonConsole"/>
     <appender-ref ref="list"/>
+    <appender-ref ref="jsonCapture"/>
 </configuration>


### PR DESCRIPTION
Closes #163

- Add `CapturingOutputStreamAppender` to the shared `logback-access-json.xml` and a test asserting the `LogstashAccessEncoder` emits a structured JSON object with the request fields (`method`, `status_code`, `requested_uri`, `@timestamp`). The JSON tests previously validated nothing about the encoded output.
- Send a divergent `Host` header via a raw socket in `localPortDoesNotChangeWithHostHeader` (servlet + reactive) so the LOCAL strategy is genuinely distinguished from the Host-header port (the test was tautological under RANDOM_PORT).

Verified green across all four example modules.