### PR TITLE
fix(tomcat): handle null request attributes from early-rejected requests

### DIFF
--- a/examples/common/src/main/java/examples/HttpClientTestUtils.java
+++ b/examples/common/src/main/java/examples/HttpClientTestUtils.java
@@ -52,15 +52,9 @@ public final class HttpClientTestUtils {
             final int port,
             final String path,
             final String hostHeader) throws IOException {
-        try (var socket = new Socket(host, port)) {
-            final var request = "GET " + path + " HTTP/1.1\r\n"
-                    + "Host: " + hostHeader + "\r\n"
-                    + "Connection: close\r\n\r\n";
-            socket.getOutputStream().write(request.getBytes(StandardCharsets.US_ASCII));
-            socket.getOutputStream().flush();
-            // Drain the response so the server completes the request and logs the access event.
-            socket.getInputStream().readAllBytes();
-        }
+        sendRawRequest(host, port, "GET " + path + " HTTP/1.1\r\n"
+                + "Host: " + hostHeader + "\r\n"
+                + "Connection: close\r\n\r\n");
     }
 
     /**
@@ -81,6 +75,8 @@ public final class HttpClientTestUtils {
             final int port,
             final String rawRequest) throws IOException {
         try (var socket = new Socket(host, port)) {
+            // Fail instead of hanging the build if the server ever stops closing the connection.
+            socket.setSoTimeout(5000);
             socket.getOutputStream().write(rawRequest.getBytes(StandardCharsets.US_ASCII));
             socket.getOutputStream().flush();
             // Drain the response so the server completes the exchange and logs the access event.

--- a/examples/common/src/main/java/examples/HttpClientTestUtils.java
+++ b/examples/common/src/main/java/examples/HttpClientTestUtils.java
@@ -64,6 +64,32 @@ public final class HttpClientTestUtils {
     }
 
     /**
+     * Sends raw bytes over a plain socket and returns the full response text.
+     *
+     * <p>The JDK HttpClient always produces a well-formed request, so this uses a plain socket to
+     * let tests exercise server parse-failure paths (for example, a malformed request line that the
+     * server rejects before normal processing but still hands to the access log).
+     *
+     * @param host       the TCP host to connect to
+     * @param port       the TCP port to connect to
+     * @param rawRequest the raw request bytes to send, as an ASCII string
+     * @return the raw response text decoded as ISO-8859-1
+     * @throws IOException if the request fails
+     */
+    public static String sendRawRequest(
+            final String host,
+            final int port,
+            final String rawRequest) throws IOException {
+        try (var socket = new Socket(host, port)) {
+            socket.getOutputStream().write(rawRequest.getBytes(StandardCharsets.US_ASCII));
+            socket.getOutputStream().flush();
+            // Drain the response so the server completes the exchange and logs the access event.
+            final var response = socket.getInputStream().readAllBytes();
+            return new String(response, StandardCharsets.ISO_8859_1);
+        }
+    }
+
+    /**
      * Sends a GET request with query parameters.
      *
      * @param url         the URL to send the request to

--- a/examples/common/src/main/java/examples/test/common/AbstractMalformedRequestAccessLogTest.java
+++ b/examples/common/src/main/java/examples/test/common/AbstractMalformedRequestAccessLogTest.java
@@ -1,0 +1,74 @@
+package examples.test.common;
+
+import ch.qos.logback.access.common.spi.IAccessEvent;
+import ch.qos.logback.core.read.ListAppender;
+import examples.AccessEventTestUtils;
+import examples.HttpClientTestUtils;
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Abstract base class for testing access logging of requests the server rejects before
+ * normal processing.
+ * <p>
+ * Servers hand such requests to the access log with unparsed or synthesized attributes:
+ * Tomcat passes an unparsed request whose getters return null, while Jetty synthesizes a
+ * placeholder request. The starter must emit an access event instead of failing on the
+ * missing values (issue #205).
+ */
+public abstract class AbstractMalformedRequestAccessLogTest {
+
+    private ListAppender<IAccessEvent> listAppender;
+
+    /**
+     * Returns the LogbackAccessContext from the Spring context.
+     *
+     * @return the LogbackAccessContext
+     */
+    protected abstract LogbackAccessContext getLogbackAccessContext();
+
+    /**
+     * Returns the local server port.
+     *
+     * @return the port number
+     */
+    protected abstract int getPort();
+
+    /**
+     * Returns the HTTP method the server reports for an unparseable request line.
+     *
+     * @return "-" on Tomcat (unparsed request, NA fallback); "BAD" on Jetty (synthesized
+     *         placeholder request)
+     */
+    protected abstract String getExpectedMalformedMethod();
+
+    @BeforeEach
+    void setUpMalformedRequestAppender() {
+        listAppender = AccessEventTestUtils.getListAppender(getLogbackAccessContext(), "list");
+        AccessEventTestUtils.reset(listAppender);
+    }
+
+    protected ListAppender<IAccessEvent> getListAppender() {
+        return listAppender;
+    }
+
+    @Test
+    void malformedRequestLineEmitsAccessEventWith400Status() throws Exception {
+        final var response = HttpClientTestUtils.sendRawRequest("localhost", getPort(), "GARBAGE\r\n\r\n");
+
+        assertThat(response).startsWith("HTTP/1.1 400");
+
+        final var events = AccessEventTestUtils.awaitEvents(listAppender);
+
+        assertThat(events).hasSize(1);
+        final var event = events.get(0);
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(event.getStatusCode()).isEqualTo(400);
+            softly.assertThat(event.getMethod()).isEqualTo(getExpectedMalformedMethod());
+        });
+    }
+}

--- a/examples/common/src/main/java/examples/test/common/AbstractMalformedRequestAccessLogTest.java
+++ b/examples/common/src/main/java/examples/test/common/AbstractMalformedRequestAccessLogTest.java
@@ -52,10 +52,6 @@ public abstract class AbstractMalformedRequestAccessLogTest {
         AccessEventTestUtils.reset(listAppender);
     }
 
-    protected ListAppender<IAccessEvent> getListAppender() {
-        return listAppender;
-    }
-
     @Test
     void malformedRequestLineEmitsAccessEventWith400Status() throws Exception {
         final var response = HttpClientTestUtils.sendRawRequest("localhost", getPort(), "GARBAGE\r\n\r\n");

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/JettyMalformedRequestAccessLogTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/JettyMalformedRequestAccessLogTest.java
@@ -1,0 +1,37 @@
+package examples.jettymvc;
+
+import examples.test.common.AbstractMalformedRequestAccessLogTest;
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+/**
+ * Malformed request access log tests for Jetty + MVC.
+ * Jetty synthesizes a "BAD /badMessage HTTP/1.0" placeholder request for unparseable requests.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class JettyMalformedRequestAccessLogTest extends AbstractMalformedRequestAccessLogTest {
+
+    @Autowired
+    LogbackAccessContext logbackAccessContext;
+
+    @LocalServerPort
+    int port;
+
+    @Override
+    protected LogbackAccessContext getLogbackAccessContext() {
+        return logbackAccessContext;
+    }
+
+    @Override
+    protected int getPort() {
+        return port;
+    }
+
+    @Override
+    protected String getExpectedMalformedMethod() {
+        return "BAD";
+    }
+}

--- a/examples/jetty-webflux/src/test/java/examples/jettywebflux/MalformedRequestAccessLogTest.java
+++ b/examples/jetty-webflux/src/test/java/examples/jettywebflux/MalformedRequestAccessLogTest.java
@@ -1,0 +1,37 @@
+package examples.jettywebflux;
+
+import examples.test.common.AbstractMalformedRequestAccessLogTest;
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+/**
+ * Malformed request access log tests for Jetty + WebFlux.
+ * Jetty synthesizes a "BAD /badMessage HTTP/1.0" placeholder request for unparseable requests.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class MalformedRequestAccessLogTest extends AbstractMalformedRequestAccessLogTest {
+
+    @Autowired
+    LogbackAccessContext logbackAccessContext;
+
+    @LocalServerPort
+    int port;
+
+    @Override
+    protected LogbackAccessContext getLogbackAccessContext() {
+        return logbackAccessContext;
+    }
+
+    @Override
+    protected int getPort() {
+        return port;
+    }
+
+    @Override
+    protected String getExpectedMalformedMethod() {
+        return "BAD";
+    }
+}

--- a/examples/tomcat-mvc/src/test/java/examples/tomcatmvc/MalformedRequestAccessLogTest.java
+++ b/examples/tomcat-mvc/src/test/java/examples/tomcatmvc/MalformedRequestAccessLogTest.java
@@ -1,0 +1,37 @@
+package examples.tomcatmvc;
+
+import examples.test.common.AbstractMalformedRequestAccessLogTest;
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+/**
+ * Malformed request access log tests for Tomcat + MVC.
+ * Tomcat rejects the request before parsing, so the event carries NA fallback values.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class MalformedRequestAccessLogTest extends AbstractMalformedRequestAccessLogTest {
+
+    @Autowired
+    LogbackAccessContext logbackAccessContext;
+
+    @LocalServerPort
+    int port;
+
+    @Override
+    protected LogbackAccessContext getLogbackAccessContext() {
+        return logbackAccessContext;
+    }
+
+    @Override
+    protected int getPort() {
+        return port;
+    }
+
+    @Override
+    protected String getExpectedMalformedMethod() {
+        return "-";
+    }
+}

--- a/examples/tomcat-webflux/src/test/java/examples/tomcatwebflux/MalformedRequestAccessLogTest.java
+++ b/examples/tomcat-webflux/src/test/java/examples/tomcatwebflux/MalformedRequestAccessLogTest.java
@@ -1,0 +1,37 @@
+package examples.tomcatwebflux;
+
+import examples.test.common.AbstractMalformedRequestAccessLogTest;
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+/**
+ * Malformed request access log tests for Tomcat + WebFlux.
+ * Tomcat rejects the request before parsing, so the event carries NA fallback values.
+ */
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class MalformedRequestAccessLogTest extends AbstractMalformedRequestAccessLogTest {
+
+    @Autowired
+    LogbackAccessContext logbackAccessContext;
+
+    @LocalServerPort
+    int port;
+
+    @Override
+    protected LogbackAccessContext getLogbackAccessContext() {
+        return logbackAccessContext;
+    }
+
+    @Override
+    protected int getPort() {
+        return port;
+    }
+
+    @Override
+    protected String getExpectedMalformedMethod() {
+        return "-";
+    }
+}

--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/AccessEventData.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/AccessEventData.kt
@@ -22,7 +22,7 @@ public data class AccessEventData(
     val sequenceNumber: Long?,
     /** Name of the thread that processed the request. */
     val threadName: String,
-    /** Server name from the Host header or server configuration. */
+    /** Server name from the Host header or server configuration, or null when unavailable (e.g., early-rejected requests). */
     val serverName: String?,
     /** Local port on which the request was received. */
     val localPort: Int,
@@ -32,9 +32,9 @@ public data class AccessEventData(
     val remoteHost: String?,
     /** Authenticated username, or null if not authenticated. */
     val remoteUser: String?,
-    /** Protocol and version (e.g., "HTTP/1.1"). */
+    /** Protocol and version (e.g., "HTTP/1.1"), or "-" when the request was rejected before parsing. */
     val protocol: String,
-    /** HTTP method (e.g., "GET", "POST"). */
+    /** HTTP method (e.g., "GET", "POST"), or "-" when the request was rejected before parsing. */
     val method: String,
     /** Request URI path without query string. */
     val requestURI: String?,

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSource.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSource.kt
@@ -40,7 +40,7 @@ internal fun createAccessEventData(
             remoteUser = resolver.resolveRemoteUser(request),
             protocol = resolver.resolveProtocol(request),
             method = resolver.resolveMethod(request),
-            requestURI = request.requestURI,
+            requestURI = resolver.resolveRequestURI(request),
             queryString = request.queryString?.let { "?$it" }.orEmpty(),
             requestURL = resolver.buildRequestURL(request),
             requestHeaderMap = TomcatRequestDataExtractor.extractHeaders(request),

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSource.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSource.kt
@@ -39,7 +39,7 @@ internal fun createAccessEventData(
             remoteHost = resolver.resolveRemoteHost(request),
             remoteUser = resolver.resolveRemoteUser(request),
             protocol = resolver.resolveProtocol(request),
-            method = request.method,
+            method = resolver.resolveMethod(request),
             requestURI = request.requestURI,
             queryString = request.queryString?.let { "?$it" }.orEmpty(),
             requestURL = resolver.buildRequestURL(request),

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestAttributeResolver.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestAttributeResolver.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.spring.boot.logback.access.tomcat
 
+import ch.qos.logback.access.common.spi.IAccessEvent.NA
 import io.github.seijikohara.spring.boot.logback.access.AccessEventData.Companion.REMOTE_USER_ATTR
 import io.github.seijikohara.spring.boot.logback.access.LocalPortStrategy
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext
@@ -15,12 +16,16 @@ import org.apache.catalina.connector.Request
  *
  * When [requestAttributesEnabled] is true, values are first looked up from request attributes
  * (set by RemoteIpValve or similar) before falling back to the direct request values.
+ *
+ * Tomcat also invokes the access log for early-rejected requests (failed TLS handshakes,
+ * unparseable request lines) whose getters return null, so resolvers return null or the
+ * logback-access NA marker instead of assuming parsed values.
  */
 internal class TomcatRequestAttributeResolver(
     private val context: LogbackAccessContext,
     private val requestAttributesEnabled: Boolean,
 ) {
-    fun resolveServerName(request: Request): String = request.accessLogAttr<String>(SERVER_NAME_ATTRIBUTE) ?: request.serverName
+    fun resolveServerName(request: Request): String? = request.accessLogAttr<String>(SERVER_NAME_ATTRIBUTE) ?: request.serverName
 
     fun resolveLocalPort(request: Request): Int =
         when (context.properties.localPortStrategy) {
@@ -28,16 +33,18 @@ internal class TomcatRequestAttributeResolver(
             LocalPortStrategy.SERVER -> request.accessLogAttr<Int>(SERVER_PORT_ATTRIBUTE) ?: request.serverPort
         }
 
-    fun resolveRemoteAddr(request: Request): String = request.accessLogAttr<String>(REMOTE_ADDR_ATTRIBUTE) ?: request.remoteAddr
+    fun resolveRemoteAddr(request: Request): String? = request.accessLogAttr<String>(REMOTE_ADDR_ATTRIBUTE) ?: request.remoteAddr
 
-    fun resolveRemoteHost(request: Request): String = request.accessLogAttr<String>(REMOTE_HOST_ATTRIBUTE) ?: request.remoteHost
+    fun resolveRemoteHost(request: Request): String? = request.accessLogAttr<String>(REMOTE_HOST_ATTRIBUTE) ?: request.remoteHost
 
     fun resolveRemoteUser(request: Request): String? = request.getAttribute(REMOTE_USER_ATTR) as? String ?: request.remoteUser
 
-    fun resolveProtocol(request: Request): String = request.accessLogAttr<String>(PROTOCOL_ATTRIBUTE) ?: request.protocol
+    fun resolveProtocol(request: Request): String = request.accessLogAttr<String>(PROTOCOL_ATTRIBUTE) ?: request.protocol ?: NA
+
+    fun resolveMethod(request: Request): String = request.method ?: NA
 
     fun buildRequestURL(request: Request): String =
-        "${request.method} ${request.requestURI}${request.queryString?.let { "?$it" }.orEmpty()} ${resolveProtocol(request)}"
+        "${resolveMethod(request)} ${request.requestURI ?: NA}${request.queryString?.let { "?$it" }.orEmpty()} ${resolveProtocol(request)}"
 
     private inline fun <reified T> Request.accessLogAttr(name: String): T? =
         if (requestAttributesEnabled) getAttribute(name) as? T else null

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestAttributeResolver.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestAttributeResolver.kt
@@ -43,8 +43,11 @@ internal class TomcatRequestAttributeResolver(
 
     fun resolveMethod(request: Request): String = request.method ?: NA
 
+    fun resolveRequestURI(request: Request): String? = request.requestURI
+
     fun buildRequestURL(request: Request): String =
-        "${resolveMethod(request)} ${request.requestURI ?: NA}${request.queryString?.let { "?$it" }.orEmpty()} ${resolveProtocol(request)}"
+        "${resolveMethod(request)} ${resolveRequestURI(request) ?: NA}" +
+            "${request.queryString?.let { "?$it" }.orEmpty()} ${resolveProtocol(request)}"
 
     private inline fun <reified T> Request.accessLogAttr(name: String): T? =
         if (requestAttributesEnabled) getAttribute(name) as? T else null

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValve.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValve.kt
@@ -44,16 +44,22 @@ internal class TomcatValve(
 
     /**
      * Tomcat's [AccessLog] contract requires implementations to tolerate null or
-     * malformed request/response objects from early-rejected requests. Extraction
-     * runs before [LogbackAccessContext.emit] (which has its own guard), so wrap it
-     * here to ensure an extraction failure never escapes into the Tomcat engine.
+     * malformed request/response objects from early-rejected requests. Parameters are
+     * declared nullable so the guard is reached instead of Kotlin's generated
+     * parameter null-check throwing first. Extraction runs before
+     * [LogbackAccessContext.emit] (which has its own guard), so wrap it here to
+     * ensure an extraction failure never escapes into the Tomcat engine.
      */
     @Suppress("TooGenericExceptionCaught")
     override fun log(
-        request: Request,
-        response: Response,
+        request: Request?,
+        response: Response?,
         time: Long,
     ) {
+        if (request == null || response == null) {
+            logger.debug { "Skipped a Tomcat access event with a null request or response" }
+            return
+        }
         try {
             createAccessEventData(logbackAccessContext, request, response, requestAttributesEnabled, time)
                 .let(::LogbackAccessEvent)

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEarlyRejectedFixtures.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEarlyRejectedFixtures.kt
@@ -1,0 +1,34 @@
+package io.github.seijikohara.spring.boot.logback.access.tomcat
+
+import org.apache.catalina.connector.Connector
+import org.apache.catalina.connector.Request
+import org.apache.catalina.connector.Response
+import java.nio.ByteBuffer
+import org.apache.coyote.OutputBuffer as CoyoteOutputBuffer
+import org.apache.coyote.Request as CoyoteRequest
+import org.apache.coyote.Response as CoyoteResponse
+
+// Mimic the objects Tomcat passes to AccessLog.log for early-rejected requests
+// (AbstractProcessor.logAccess): a connector Request over an empty coyote request whose
+// getters return null. Real Tomcat objects are used because a relaxed mock returns ""
+// instead of null and would mask platform-type null-check failures.
+
+// A bare Connector skips lifecycle init; set parseBodyMethods so parameter parsing
+// sees the initialized default, as it would on a running connector.
+internal fun earlyRejectedRequest(): Request = Request(Connector("HTTP/1.1").apply { parseBodyMethods = "POST" }, CoyoteRequest())
+
+// A processor always installs an output buffer before logging; a bare coyote response
+// has none, so install a no-op one for getBytesWritten().
+internal fun earlyRejectedResponse(): Response =
+    Response(
+        CoyoteResponse().apply {
+            status = 400
+            setOutputBuffer(
+                object : CoyoteOutputBuffer {
+                    override fun doWrite(chunk: ByteBuffer): Int = 0
+
+                    override fun getBytesWritten(): Long = 0L
+                },
+            )
+        },
+    )

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSourceSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSourceSpec.kt
@@ -14,11 +14,8 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
-import org.apache.catalina.connector.Connector
 import org.apache.catalina.connector.Request
 import org.apache.catalina.connector.Response
-import org.apache.coyote.Request as CoyoteRequest
-import org.apache.coyote.Response as CoyoteResponse
 
 class TomcatEventSourceSpec :
     FunSpec({
@@ -49,26 +46,6 @@ class TomcatEventSourceSpec :
             }
 
         fun response(): Response = mockk(relaxed = true) { every { status } returns 200 }
-
-        // Mimic the objects Tomcat passes to AccessLog.log for early-rejected requests
-        // (AbstractProcessor.logAccess): a connector Request over an empty coyote request.
-        // A bare Connector skips lifecycle init, so set parseBodyMethods as a running
-        // connector would; a processor always installs an output buffer before logging.
-        fun earlyRejectedRequest(): Request = Request(Connector("HTTP/1.1").apply { parseBodyMethods = "POST" }, CoyoteRequest())
-
-        fun earlyRejectedResponse(): Response =
-            Response(
-                CoyoteResponse().apply {
-                    status = 400
-                    setOutputBuffer(
-                        object : org.apache.coyote.OutputBuffer {
-                            override fun doWrite(chunk: java.nio.ByteBuffer): Int = 0
-
-                            override fun getBytesWritten(): Long = 0L
-                        },
-                    )
-                },
-            )
 
         fun event(
             elapsedTimeNanos: Long,
@@ -110,8 +87,7 @@ class TomcatEventSourceSpec :
         test("applies null and NA fallbacks when Tomcat logs an early-rejected request") {
             // Tomcat access-logs failed TLS handshakes and unparseable request lines through
             // AbstractProcessor.logAccess(), which passes a connector Request backed by an empty
-            // coyote request whose getters return null (issue #205). Real Tomcat objects are used
-            // here because a relaxed mock returns "" instead of null and would mask the failure.
+            // coyote request whose getters return null (issue #205).
             val request = earlyRejectedRequest()
             val response = earlyRejectedResponse()
 

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSourceSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSourceSpec.kt
@@ -1,6 +1,7 @@
 package io.github.seijikohara.spring.boot.logback.access.tomcat
 
 import ch.qos.logback.access.common.spi.AccessContext
+import ch.qos.logback.access.common.spi.IAccessEvent.NA
 import ch.qos.logback.core.spi.SequenceNumberGenerator
 import io.github.seijikohara.spring.boot.logback.access.AccessEventData
 import io.github.seijikohara.spring.boot.logback.access.LocalPortStrategy
@@ -13,8 +14,11 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import org.apache.catalina.connector.Connector
 import org.apache.catalina.connector.Request
 import org.apache.catalina.connector.Response
+import org.apache.coyote.Request as CoyoteRequest
+import org.apache.coyote.Response as CoyoteResponse
 
 class TomcatEventSourceSpec :
     FunSpec({
@@ -45,6 +49,26 @@ class TomcatEventSourceSpec :
             }
 
         fun response(): Response = mockk(relaxed = true) { every { status } returns 200 }
+
+        // Mimic the objects Tomcat passes to AccessLog.log for early-rejected requests
+        // (AbstractProcessor.logAccess): a connector Request over an empty coyote request.
+        // A bare Connector skips lifecycle init, so set parseBodyMethods as a running
+        // connector would; a processor always installs an output buffer before logging.
+        fun earlyRejectedRequest(): Request = Request(Connector("HTTP/1.1").apply { parseBodyMethods = "POST" }, CoyoteRequest())
+
+        fun earlyRejectedResponse(): Response =
+            Response(
+                CoyoteResponse().apply {
+                    status = 400
+                    setOutputBuffer(
+                        object : org.apache.coyote.OutputBuffer {
+                            override fun doWrite(chunk: java.nio.ByteBuffer): Int = 0
+
+                            override fun getBytesWritten(): Long = 0L
+                        },
+                    )
+                },
+            )
 
         fun event(
             elapsedTimeNanos: Long,
@@ -81,5 +105,25 @@ class TomcatEventSourceSpec :
             val data = event(elapsedTimeNanos = 0L, context = context(generator = generator))
 
             data.sequenceNumber shouldBe 42L
+        }
+
+        test("applies null and NA fallbacks when Tomcat logs an early-rejected request") {
+            // Tomcat access-logs failed TLS handshakes and unparseable request lines through
+            // AbstractProcessor.logAccess(), which passes a connector Request backed by an empty
+            // coyote request whose getters return null (issue #205). Real Tomcat objects are used
+            // here because a relaxed mock returns "" instead of null and would mask the failure.
+            val request = earlyRejectedRequest()
+            val response = earlyRejectedResponse()
+
+            val data = createAccessEventData(context(), request, response, requestAttributesEnabled = false, elapsedTimeNanos = 0L)
+
+            data.serverName.shouldBeNull()
+            data.remoteAddr.shouldBeNull()
+            data.remoteHost.shouldBeNull()
+            data.method shouldBe NA
+            data.protocol shouldBe NA
+            data.requestURI.shouldBeNull()
+            data.requestURL shouldBe "$NA $NA $NA"
+            data.statusCode shouldBe 400
         }
     })

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestAttributeResolverSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestAttributeResolverSpec.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.spring.boot.logback.access.tomcat
 
+import ch.qos.logback.access.common.spi.IAccessEvent.NA
 import io.github.seijikohara.spring.boot.logback.access.AccessEventData.Companion.REMOTE_USER_ATTR
 import io.github.seijikohara.spring.boot.logback.access.LocalPortStrategy
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext
@@ -161,6 +162,58 @@ class TomcatRequestAttributeResolverSpec :
                 every { request.remoteUser } returns null
 
                 resolver.resolveRemoteUser(request) shouldBe null
+            }
+        }
+
+        context("early-rejected requests") {
+            // Tomcat access-logs failed TLS handshakes and unparseable requests with an
+            // unparsed Request whose getters return null (issue #205).
+            test("resolveServerName returns null when the request has no parsed server name") {
+                val context = mockContext()
+                val resolver = TomcatRequestAttributeResolver(context, requestAttributesEnabled = false)
+                val request = mockk<Request>(relaxed = true)
+                every { request.serverName } returns null
+
+                resolver.resolveServerName(request) shouldBe null
+            }
+
+            test("resolveRemoteAddr returns null when the request has no remote address") {
+                val context = mockContext()
+                val resolver = TomcatRequestAttributeResolver(context, requestAttributesEnabled = false)
+                val request = mockk<Request>(relaxed = true)
+                every { request.remoteAddr } returns null
+
+                resolver.resolveRemoteAddr(request) shouldBe null
+            }
+
+            test("resolveRemoteHost returns null when the request has no remote host") {
+                val context = mockContext()
+                val resolver = TomcatRequestAttributeResolver(context, requestAttributesEnabled = false)
+                val request = mockk<Request>(relaxed = true)
+                every { request.remoteHost } returns null
+
+                resolver.resolveRemoteHost(request) shouldBe null
+            }
+
+            test("resolveProtocol falls back to NA when the request has no protocol") {
+                val context = mockContext()
+                val resolver = TomcatRequestAttributeResolver(context, requestAttributesEnabled = false)
+                val request = mockk<Request>(relaxed = true)
+                every { request.protocol } returns null
+
+                resolver.resolveProtocol(request) shouldBe NA
+            }
+
+            test("buildRequestURL substitutes NA for missing method, URI, and protocol") {
+                val context = mockContext()
+                val resolver = TomcatRequestAttributeResolver(context, requestAttributesEnabled = false)
+                val request = mockk<Request>(relaxed = true)
+                every { request.method } returns null
+                every { request.requestURI } returns null
+                every { request.queryString } returns null
+                every { request.protocol } returns null
+
+                resolver.buildRequestURL(request) shouldBe "$NA $NA $NA"
             }
         }
 

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValveSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValveSpec.kt
@@ -1,15 +1,37 @@
 package io.github.seijikohara.spring.boot.logback.access.tomcat
 
+import ch.qos.logback.access.common.spi.AccessContext
+import ch.qos.logback.access.common.spi.IAccessEvent.NA
+import io.github.seijikohara.spring.boot.logback.access.LocalPortStrategy
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessEvent
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import org.apache.catalina.connector.Connector
 import org.apache.catalina.connector.Request
 import org.apache.catalina.connector.Response
+import org.apache.coyote.Request as CoyoteRequest
+import org.apache.coyote.Response as CoyoteResponse
 
 class TomcatValveSpec :
     FunSpec({
+        fun properties(): LogbackAccessProperties =
+            LogbackAccessProperties(
+                enabled = true,
+                configLocation = null,
+                localPortStrategy = LocalPortStrategy.SERVER,
+                tomcat = LogbackAccessProperties.TomcatProperties(requestAttributesEnabled = null),
+                teeFilter = LogbackAccessProperties.TeeFilterProperties(false, null, null, 65536L, null),
+                filter = LogbackAccessProperties.FilterProperties(null, null),
+            )
+
         test("log does not propagate exceptions thrown while extracting access-event data") {
             val context = mockk<LogbackAccessContext>(relaxed = true)
             val request =
@@ -21,5 +43,46 @@ class TomcatValveSpec :
             val valve = TomcatValve(context)
 
             shouldNotThrowAny { valve.log(request, response, 0L) }
+        }
+
+        test("log emits an access event for an early-rejected request instead of dropping it") {
+            // Tomcat invokes AccessLog.log for failed TLS handshakes and unparseable request
+            // lines with an unparsed Request whose getters return null (issue #205). The valve
+            // must still emit an event; the exception guard alone would silently drop it.
+            val emitted = slot<LogbackAccessEvent>()
+            val context =
+                mockk<LogbackAccessContext> {
+                    every { properties } returns properties()
+                    every { accessContext } returns
+                        mockk<AccessContext>(relaxed = true) {
+                            every { sequenceNumberGenerator } returns null
+                        }
+                    every { emit(capture(emitted)) } just runs
+                }
+            // Mimic the objects Tomcat passes to AccessLog.log for early-rejected requests
+            // (AbstractProcessor.logAccess): a connector Request over an empty coyote request.
+            // A bare Connector skips lifecycle init, so set parseBodyMethods as a running
+            // connector would; a processor always installs an output buffer before logging.
+            val request = Request(Connector("HTTP/1.1").apply { parseBodyMethods = "POST" }, CoyoteRequest())
+            val response =
+                Response(
+                    CoyoteResponse().apply {
+                        status = 400
+                        setOutputBuffer(
+                            object : org.apache.coyote.OutputBuffer {
+                                override fun doWrite(chunk: java.nio.ByteBuffer): Int = 0
+
+                                override fun getBytesWritten(): Long = 0L
+                            },
+                        )
+                    },
+                )
+
+            TomcatValve(context).log(request, response, 0L)
+
+            emitted.captured.serverName shouldBe NA
+            emitted.captured.method shouldBe NA
+            emitted.captured.protocol shouldBe NA
+            emitted.captured.statusCode shouldBe 400
         }
     })

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValveSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatValveSpec.kt
@@ -14,11 +14,10 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import io.mockk.slot
-import org.apache.catalina.connector.Connector
+import io.mockk.verify
+import org.apache.catalina.AccessLog
 import org.apache.catalina.connector.Request
 import org.apache.catalina.connector.Response
-import org.apache.coyote.Request as CoyoteRequest
-import org.apache.coyote.Response as CoyoteResponse
 
 class TomcatValveSpec :
     FunSpec({
@@ -31,6 +30,16 @@ class TomcatValveSpec :
                 teeFilter = LogbackAccessProperties.TeeFilterProperties(false, null, null, 65536L, null),
                 filter = LogbackAccessProperties.FilterProperties(null, null),
             )
+
+        test("log tolerates a null request and response from the AccessLog contract") {
+            val context = mockk<LogbackAccessContext>(relaxed = true)
+            // Call through the Java interface: its parameters are platform types, so Tomcat
+            // could hand over nulls that a Kotlin caller cannot express.
+            val accessLog: AccessLog = TomcatValve(context)
+
+            shouldNotThrowAny { accessLog.log(null, null, 0L) }
+            verify(exactly = 0) { context.emit(any()) }
+        }
 
         test("log does not propagate exceptions thrown while extracting access-event data") {
             val context = mockk<LogbackAccessContext>(relaxed = true)
@@ -59,26 +68,8 @@ class TomcatValveSpec :
                         }
                     every { emit(capture(emitted)) } just runs
                 }
-            // Mimic the objects Tomcat passes to AccessLog.log for early-rejected requests
-            // (AbstractProcessor.logAccess): a connector Request over an empty coyote request.
-            // A bare Connector skips lifecycle init, so set parseBodyMethods as a running
-            // connector would; a processor always installs an output buffer before logging.
-            val request = Request(Connector("HTTP/1.1").apply { parseBodyMethods = "POST" }, CoyoteRequest())
-            val response =
-                Response(
-                    CoyoteResponse().apply {
-                        status = 400
-                        setOutputBuffer(
-                            object : org.apache.coyote.OutputBuffer {
-                                override fun doWrite(chunk: java.nio.ByteBuffer): Int = 0
 
-                                override fun getBytesWritten(): Long = 0L
-                            },
-                        )
-                    },
-                )
-
-            TomcatValve(context).log(request, response, 0L)
+            TomcatValve(context).log(earlyRejectedRequest(), earlyRejectedResponse(), 0L)
 
             emitted.captured.serverName shouldBe NA
             emitted.captured.method shouldBe NA


### PR DESCRIPTION
## Summary

Fixes #205 — `NullPointerException: getServerName(...) must not be null` thrown while capturing the access event for a failed TLS handshake, which dropped the access log entry and polluted the application log with a stack trace per failed handshake.

## Root Cause

Tomcat invokes the access log for early-rejected connections (failed TLS handshakes via `SocketEvent.CONNECT_FAIL`, unparseable request lines) through `AbstractProcessor.logAccess`, passing an unparsed `Request` whose getters (`getServerName`, `getProtocol`, `getMethod`, `getRequestURI`, `getRemoteAddr`, `getRemoteHost`) all return null. `TomcatRequestAttributeResolver` declared non-null return types, so the Kotlin platform-type check threw an NPE on the first null attribute. The valve's extraction guard caught the exception but the event was lost.

Fixing `serverName` alone is insufficient: the extraction then fails at `getProtocol` and `getMethod` on the same path, and a malformed request line on a plain HTTP port fails at `getMethod` (reproduced: `NullPointerException: getMethod(...) must not be null`).

## Changes

- `TomcatRequestAttributeResolver.resolveServerName/resolveRemoteAddr/resolveRemoteHost` return `String?`; `AccessEventData` already accepts null for these fields and `LogbackAccessEvent` maps null to `-` (NA).
- `resolveProtocol` and the new `resolveMethod` fall back to the logback-access NA marker (`-`), matching vanilla logback-access behavior; `buildRequestURL` substitutes NA for missing request-line parts instead of rendering the literal string `null`.
- No public API change (`apiCheck` passes; `AccessEventData` is untouched).

## Tests

- Resolver unit tests for null request values on every affected attribute (previously only covered the attribute-vs-request fallback with non-null values).
- Event source and valve unit tests built on **real Tomcat objects** mimicking `AbstractProcessor.logAccess` — a relaxed mock returns `""` instead of null for String getters, which is exactly why the existing suite missed this bug.
- New `AbstractMalformedRequestAccessLogTest` integration test (raw-socket malformed request line → 400) for all four server/framework combinations: Tomcat emits the event with NA fallbacks; Jetty pins its existing synthesized `BAD /badMessage HTTP/1.0` behavior.

All tests were written first and observed failing with the reported NPEs before the fix (TDD).

## Verification

`./gradlew clean build` passes (Spotless, Detekt, apiCheck, unit tests, and the integration tests of all four example apps).