### PR TITLE
fix(jetty): guard access-event extraction against exceptions

### DIFF
--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/jetty/JettyRequestLog.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/jetty/JettyRequestLog.kt
@@ -1,5 +1,6 @@
 package io.github.seijikohara.spring.boot.logback.access.jetty
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessEvent
 import org.eclipse.jetty.server.Request
@@ -22,11 +23,28 @@ import org.eclipse.jetty.server.Response
 internal class JettyRequestLog(
     private val logbackAccessContext: LogbackAccessContext,
 ) : RequestLog {
+    /**
+     * Jetty also logs rejected requests through a synthesized placeholder request, so the
+     * inputs are not guaranteed to be fully populated. Extraction runs before
+     * [LogbackAccessContext.emit] (which has its own guard), so wrap it here to ensure an
+     * extraction failure never escapes into Jetty's request-completion path, mirroring the
+     * Tomcat valve.
+     */
+    @Suppress("TooGenericExceptionCaught")
     override fun log(
         request: Request,
         response: Response,
-    ): Unit =
-        createAccessEventData(logbackAccessContext, request, response)
-            .let(::LogbackAccessEvent)
-            .let(logbackAccessContext::emit)
+    ) {
+        try {
+            createAccessEventData(logbackAccessContext, request, response)
+                .let(::LogbackAccessEvent)
+                .let(logbackAccessContext::emit)
+        } catch (e: Exception) {
+            logger.error(e) { "Failed to capture Jetty access event" }
+        }
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
 }

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/jetty/JettyRequestLogSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/jetty/JettyRequestLogSpec.kt
@@ -1,0 +1,75 @@
+package io.github.seijikohara.spring.boot.logback.access.jetty
+
+import ch.qos.logback.access.common.spi.AccessContext
+import io.github.seijikohara.spring.boot.logback.access.LocalPortStrategy
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessEvent
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.slot
+import org.eclipse.jetty.server.Request
+import org.eclipse.jetty.server.Response
+
+class JettyRequestLogSpec :
+    FunSpec({
+        fun properties(): LogbackAccessProperties =
+            LogbackAccessProperties(
+                enabled = true,
+                configLocation = null,
+                localPortStrategy = LocalPortStrategy.SERVER,
+                tomcat = LogbackAccessProperties.TomcatProperties(requestAttributesEnabled = null),
+                teeFilter = LogbackAccessProperties.TeeFilterProperties(false, null, null, 65536L, null),
+                filter = LogbackAccessProperties.FilterProperties(null, null),
+            )
+
+        test("log does not propagate exceptions thrown while extracting access-event data") {
+            val context = mockk<LogbackAccessContext>(relaxed = true)
+            val request =
+                mockk<Request>(relaxed = true) {
+                    // Simulate a request whose extraction fails mid-flight.
+                    every { beginNanoTime } throws RuntimeException("extraction failure")
+                }
+            val response = mockk<Response>(relaxed = true)
+
+            shouldNotThrowAny { JettyRequestLog(context).log(request, response) }
+        }
+
+        test("log emits the captured access event") {
+            mockkStatic(Request::class, Response::class) {
+                val emitted = slot<LogbackAccessEvent>()
+                val context =
+                    mockk<LogbackAccessContext> {
+                        every { properties } returns properties()
+                        every { accessContext } returns
+                            mockk<AccessContext>(relaxed = true) {
+                                every { sequenceNumberGenerator } returns null
+                            }
+                        every { emit(capture(emitted)) } just runs
+                    }
+                val request =
+                    mockk<Request>(relaxed = true) {
+                        every { beginNanoTime } returns System.nanoTime()
+                        every { getSession(false) } returns null
+                        every { method } returns "GET"
+                    }
+                val response = mockk<Response>(relaxed = true) { every { status } returns 200 }
+                every { Request.getServerName(request) } returns "localhost"
+                every { Request.getServerPort(request) } returns 8080
+                every { Request.getRemoteAddr(request) } returns "127.0.0.1"
+                every { Request.getCookies(request) } returns emptyList()
+                every { Response.getContentBytesWritten(response) } returns 0L
+
+                JettyRequestLog(context).log(request, response)
+
+                emitted.captured.method shouldBe "GET"
+                emitted.captured.statusCode shouldBe 200
+            }
+        }
+    })


### PR DESCRIPTION
## Summary

Hardening companion to #206: `JettyRequestLog.log` had no exception guard, unlike `TomcatValve.log`.

During the verification of #205, Jetty was confirmed **not** affected by the null-attribute NPE (Jetty synthesizes a `BAD /badMessage HTTP/1.0` placeholder request with non-null attributes for rejected requests, and does not invoke the request log for failed TLS handshakes). However, an extraction failure of any kind would propagate into Jetty's request-completion path and lose the event without the starter-side guard the Tomcat integration already has.

## Changes

- Wrap extraction in `JettyRequestLog.log` with the same guard as `TomcatValve.log`: log an ERROR and never propagate.
- Add `JettyRequestLogSpec` covering both the guard (extraction failure does not propagate) and the emit passthrough (a captured event reaches `LogbackAccessContext.emit`).

The guard test was written first and observed failing (exception propagated) before the fix.

## Verification

`./gradlew clean build` passes (Spotless, Detekt, apiCheck, unit tests, and the integration tests of all four example apps).