### PR TITLE
fix(core): treat empty URL include patterns as no filtering

### DIFF
--- a/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContext.kt
+++ b/logback-access-spring-boot-starter-core/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContext.kt
@@ -28,13 +28,23 @@ public class LogbackAccessContext(
     /** The underlying Logback-access context. */
     public val accessContext: AccessContext = AccessContext()
 
-    /** Compiled regex patterns for URL filtering, cached for performance. */
+    /**
+     * Compiled regex patterns for URL filtering, cached for performance.
+     *
+     * An empty list is normalized to null (no filtering): relaxed binding produces an
+     * empty, non-null list from an empty property value, and matching against an empty
+     * list would silently drop every event.
+     */
     private val includePatterns: List<Regex>? =
-        properties.filter.includeUrlPatterns?.map { it.toValidRegex("include") }
+        properties.filter.includeUrlPatterns
+            ?.takeIf { it.isNotEmpty() }
+            ?.map { it.toValidRegex("include") }
 
-    /** Compiled regex patterns for URL exclusion, cached for performance. */
+    /** Compiled regex patterns for URL exclusion, cached for performance. Empty lists are normalized like [includePatterns]. */
     private val excludePatterns: List<Regex>? =
-        properties.filter.excludeUrlPatterns?.map { it.toValidRegex("exclude") }
+        properties.filter.excludeUrlPatterns
+            ?.takeIf { it.isNotEmpty() }
+            ?.map { it.toValidRegex("exclude") }
 
     init {
         val (name, resource) = resolveConfig(properties, resourceLoader)

--- a/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContextSpec.kt
+++ b/logback-access-spring-boot-starter-core/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/LogbackAccessContextSpec.kt
@@ -136,6 +136,32 @@ class LogbackAccessContextSpec :
                 }
             }
 
+            test("logs event when include patterns list is empty") {
+                val properties = createProperties(includeUrlPatterns = emptyList())
+                val context = createContext(properties)
+
+                try {
+                    context.emit(createTestEvent("/api/users"))
+
+                    getListAppender(context).list shouldHaveSize 1
+                } finally {
+                    context.close()
+                }
+            }
+
+            test("logs event when exclude patterns list is empty") {
+                val properties = createProperties(excludeUrlPatterns = emptyList())
+                val context = createContext(properties)
+
+                try {
+                    context.emit(createTestEvent("/api/users"))
+
+                    getListAppender(context).list shouldHaveSize 1
+                } finally {
+                    context.close()
+                }
+            }
+
             test("catches exceptions from appenders without propagating") {
                 val properties = createProperties()
                 val context = createContext(properties)


### PR DESCRIPTION
## Summary

An empty, non-null `logback.access.filter.include-url-patterns` list silently disabled **all** access logging: `matchesIncludePatterns` only fell back to "match everything" when the list was `null`, so an empty list matched no URI and every event was dropped without any diagnostic.

The state is reachable through ordinary configuration, not just deliberate misuse: Spring Boot's relaxed binder converts an empty property value (e.g. `include-url-patterns: ${ACCESS_LOG_INCLUDE:}` with the variable unset, or an explicit `include-url-patterns: ""`) into an empty non-null list.

## Changes

- `LogbackAccessContext`: normalize empty include/exclude pattern lists to `null` (unspecified) before compiling them. The exclude side was not affected by the bug (empty and null behave identically there) but is normalized the same way for symmetry.
- `LogbackAccessContextSpec`: regression tests for empty include and exclude lists.

## Testing

- Added test fails before the fix (`Collection should have size 1 but has size 0`) and passes after.
- `./gradlew clean build` passes (Spotless, Detekt, apiCheck, all module tests).