### PR TITLE
fix(starter): harden default TeeFilter body-capture policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ Reference the captured bodies with `%requestContent` and `%responseContent`.
 | `logback.access.tee-filter.include-hosts` | Comma-separated host names that activate the filter. | All hosts |
 | `logback.access.tee-filter.exclude-hosts` | Comma-separated host names that bypass the filter. | None |
 | `logback.access.tee-filter.max-payload-size` | Maximum payload size in bytes that appears in log output. Larger bodies are replaced with a sentinel. | `65536` |
-| `logback.access.tee-filter.allowed-content-types` | Content-Type patterns allowed for body capture. When set, this list completely replaces the built-in defaults. | Text, JSON, XML, and form-urlencoded types ([details](https://seijikohara.github.io/logback-access-spring-boot-starter/guide/advanced#teefilter)) |
+| `logback.access.tee-filter.allowed-content-types` | Content-Type patterns allowed for body capture. When set, this list completely replaces the built-in defaults. | Text, JSON, and XML types ([details](https://seijikohara.github.io/logback-access-spring-boot-starter/guide/advanced#teefilter)) |
 
-> **Security Warning**: Captured bodies can contain credentials, tokens, and personally identifiable information. Restrict the capture scope with `include-hosts` / `exclude-hosts`, and apply masking before the data leaves the host.
+> **Security Warning**: Captured bodies can contain credentials, tokens, and personally identifiable information. Restrict the capture scope with `include-hosts` / `exclude-hosts`, and apply masking before the data leaves the host. Form submissions (`application/x-www-form-urlencoded`) and non-empty payloads without a `Content-Type` are suppressed unless explicitly added to `allowed-content-types`.
 >
 > Note also that `max-payload-size` only limits what reaches the log output — TeeFilter still buffers the full body in memory regardless.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,9 +49,11 @@ Access logs record attacker-controlled request data. Configure logging defensive
 - **Secrets in patterns.** Avoid `%{Authorization}i`, `%{Cookie}i`, `%{Set-Cookie}o`, individual
   cookie values, and the session ID in production patterns. These can expose bearer tokens,
   credentials, and session identifiers.
-- **Request/response bodies.** TeeFilter is disabled by default. Enable it only when body capture is
-  required, restrict it with `allowed-content-types` and `include-hosts` / `exclude-hosts`, and note
-  that it buffers full bodies in memory regardless of `max-payload-size`.
+- **Request/response bodies.** TeeFilter is disabled by default. Even when enabled, form submissions
+  (`application/x-www-form-urlencoded`) and non-empty payloads without a `Content-Type` are suppressed
+  unless explicitly added to `allowed-content-types`. Enable it only when body capture is required,
+  restrict it with `allowed-content-types` and `include-hosts` / `exclude-hosts`, and note that it
+  buffers full bodies in memory regardless of `max-payload-size`.
 
 See the [advanced guide](https://seijikohara.github.io/logback-access-spring-boot-starter/guide/advanced) for body-capture configuration and platform behavior.
 

--- a/docs/guide/advanced.md
+++ b/docs/guide/advanced.md
@@ -45,7 +45,7 @@ Reference the captured bodies with the `%requestContent` and `%responseContent` 
 
 ### Body Capture Policy
 
-Before captured bytes reach the log output, the starter evaluates a capture policy against the response's `Content-Type` and payload size. Binary content and oversized payloads are replaced with a sentinel.
+Before captured bytes reach the log output, the starter evaluates a capture policy against the response's `Content-Type` and payload size. Binary content and oversized payloads are replaced with a sentinel. Empty payloads are never replaced with a sentinel.
 
 **Default allowed content types:**
 
@@ -54,14 +54,16 @@ Before captured bytes reach the log output, the starter evaluates a capture poli
 - `application/xml`
 - `application/*+json` (application/vnd.api+json, etc.)
 - `application/*+xml` (application/atom+xml, etc.)
-- `application/x-www-form-urlencoded`
+
+`application/x-www-form-urlencoded` is deliberately not in the default list: login forms (for example Spring Security's `formLogin()`) post credentials with that content type. Add it to `allowed-content-types` explicitly when form bodies must be captured.
 
 **Sentinel values:**
 
 | Condition | Sentinel |
 |-----------|----------|
 | Image content (`image/*`) | `[IMAGE CONTENTS SUPPRESSED]` |
-| Other binary content | `[BINARY CONTENT SUPPRESSED]` |
+| Other binary or disallowed content | `[BINARY CONTENT SUPPRESSED]` |
+| Missing `Content-Type` header (non-empty payload) | `[BINARY CONTENT SUPPRESSED]` |
 | Payload exceeds `max-payload-size` | `[CONTENT TOO LARGE]` |
 
 **Custom content types:**
@@ -85,7 +87,7 @@ Supplying `allowed-content-types` completely replaces the built-in list (overrid
 :::
 
 ::: info
-When `tee-filter.enabled` is `false` (the default), `%requestContent` and `%responseContent` always render as empty. This also suppresses the form-data reconstruction path for `application/x-www-form-urlencoded` requests, so credentials submitted as form fields never leak into the access log unless TeeFilter is explicitly enabled.
+When `tee-filter.enabled` is `false` (the default), `%requestContent` and `%responseContent` always render as empty. This also suppresses the form-data reconstruction path for `application/x-www-form-urlencoded` requests. Even when TeeFilter is enabled, form bodies render as `[BINARY CONTENT SUPPRESSED]` unless `application/x-www-form-urlencoded` is explicitly added to `allowed-content-types`, so credentials submitted as form fields never leak into the access log by default.
 :::
 
 ### Character Encoding

--- a/docs/ja/guide/advanced.md
+++ b/docs/ja/guide/advanced.md
@@ -45,7 +45,7 @@ logback:
 
 ### ボディキャプチャポリシー
 
-キャプチャしたバイト列をログ出力に含める前に、スターターはレスポンスの`Content-Type`とペイロードサイズに基づきキャプチャポリシーを評価します。バイナリコンテンツや巨大なペイロードはセンチネル値に置換されます。
+キャプチャしたバイト列をログ出力に含める前に、スターターはレスポンスの`Content-Type`とペイロードサイズに基づきキャプチャポリシーを評価します。バイナリコンテンツや巨大なペイロードはセンチネル値に置換されます。空のペイロードがセンチネル値に置換されることはありません。
 
 **デフォルトで許可されるコンテンツタイプ:**
 
@@ -54,14 +54,16 @@ logback:
 - `application/xml`
 - `application/*+json`（application/vnd.api+jsonなど）
 - `application/*+xml`（application/atom+xmlなど）
-- `application/x-www-form-urlencoded`
+
+`application/x-www-form-urlencoded`はデフォルト一覧に意図的に含まれていません。ログインフォーム（例: Spring Securityの`formLogin()`）はこのコンテンツタイプで認証情報を送信するためです。フォームボディのキャプチャが必要な場合は`allowed-content-types`に明示的に追加してください。
 
 **センチネル値:**
 
 | 条件 | センチネル |
 |------|-----------|
 | 画像コンテンツ（`image/*`） | `[IMAGE CONTENTS SUPPRESSED]` |
-| その他のバイナリコンテンツ | `[BINARY CONTENT SUPPRESSED]` |
+| その他のバイナリ・非許可コンテンツ | `[BINARY CONTENT SUPPRESSED]` |
+| `Content-Type`ヘッダーなし（空でないペイロード） | `[BINARY CONTENT SUPPRESSED]` |
 | ペイロードが`max-payload-size`を超過 | `[CONTENT TOO LARGE]` |
 
 **カスタムコンテンツタイプ:**
@@ -85,7 +87,7 @@ logback:
 :::
 
 ::: info
-`tee-filter.enabled`が`false`（デフォルト）の場合、`%requestContent`と`%responseContent`は常に空を返します。これにより、`application/x-www-form-urlencoded`リクエストのフォームデータ再構成パスも抑制されます。TeeFilterを明示的に有効化しない限り、フォームに送信された認証情報などがアクセスログに漏洩することはありません。
+`tee-filter.enabled`が`false`（デフォルト）の場合、`%requestContent`と`%responseContent`は常に空を返します。これにより、`application/x-www-form-urlencoded`リクエストのフォームデータ再構成パスも抑制されます。TeeFilterを有効化した場合でも、`allowed-content-types`に`application/x-www-form-urlencoded`を明示的に追加しない限りフォームボディは`[BINARY CONTENT SUPPRESSED]`として出力されるため、フォームに送信された認証情報がデフォルト設定でアクセスログに漏洩することはありません。
 :::
 
 ### 文字エンコーディング

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/BodyCapturePolicy.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/BodyCapturePolicy.kt
@@ -12,6 +12,12 @@ internal object BodyCapturePolicy {
     private const val BINARY_CONTENT_SUPPRESSED = "[BINARY CONTENT SUPPRESSED]"
     private const val CONTENT_TOO_LARGE = "[CONTENT TOO LARGE]"
 
+    /**
+     * Form submissions (application/x-www-form-urlencoded) are deliberately excluded:
+     * login forms (for example Spring Security's formLogin) post credentials with that
+     * content type, so capturing it by default would write plaintext credentials to the
+     * access log. Operators opt in via allowed-content-types.
+     */
     private val DEFAULT_ALLOWED_CONTENT_TYPES =
         listOf(
             "text/*",
@@ -19,11 +25,14 @@ internal object BodyCapturePolicy {
             "application/xml",
             "application/*+json",
             "application/*+xml",
-            "application/x-www-form-urlencoded",
         )
 
     /**
      * Evaluates whether body content should be suppressed.
+     *
+     * Empty payloads are always allowed because there is nothing to expose.
+     * Non-empty payloads without a Content-Type are suppressed because the
+     * allowlist cannot classify them.
      *
      * @return null if capture is allowed, or a sentinel string if suppressed.
      */
@@ -34,6 +43,7 @@ internal object BodyCapturePolicy {
     ): String? =
         when {
             payloadSize > properties.maxPayloadSize -> CONTENT_TOO_LARGE
+            payloadSize == 0L -> null
             !isAllowedContentType(contentType, properties) -> selectBinarySentinel(contentType)
             else -> null
         }
@@ -62,7 +72,7 @@ internal object BodyCapturePolicy {
             ?.let { mimeType ->
                 (properties.allowedContentTypes ?: DEFAULT_ALLOWED_CONTENT_TYPES)
                     .any { matchesMimePattern(mimeType, it.lowercase()) }
-            } ?: true
+            } ?: false
 
     private fun selectBinarySentinel(contentType: String?): String =
         contentType

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/BodyCapturePolicySpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/BodyCapturePolicySpec.kt
@@ -39,9 +39,20 @@ class BodyCapturePolicySpec :
             test("allows application/atom+xml") {
                 BodyCapturePolicy.evaluate("application/atom+xml", 100L, defaultProperties) shouldBe null
             }
+        }
 
-            test("allows application/x-www-form-urlencoded") {
-                BodyCapturePolicy.evaluate("application/x-www-form-urlencoded", 100L, defaultProperties) shouldBe null
+        context("evaluate — form data") {
+            test("suppresses application/x-www-form-urlencoded by default") {
+                BodyCapturePolicy.evaluate("application/x-www-form-urlencoded", 100L, defaultProperties) shouldBe
+                    "[BINARY CONTENT SUPPRESSED]"
+            }
+
+            test("allows form data when explicitly listed in allowed content types") {
+                val customProperties =
+                    defaultProperties.copy(
+                        allowedContentTypes = listOf("application/x-www-form-urlencoded"),
+                    )
+                BodyCapturePolicy.evaluate("application/x-www-form-urlencoded", 100L, customProperties) shouldBe null
             }
         }
 
@@ -113,8 +124,19 @@ class BodyCapturePolicySpec :
         }
 
         context("evaluate — null content type") {
-            test("allows null content type (treated as text)") {
-                BodyCapturePolicy.evaluate(null, 100L, defaultProperties) shouldBe null
+            test("suppresses null content type when a payload is present") {
+                BodyCapturePolicy.evaluate(null, 100L, defaultProperties) shouldBe
+                    "[BINARY CONTENT SUPPRESSED]"
+            }
+        }
+
+        context("evaluate — empty payload") {
+            test("allows empty payload with null content type") {
+                BodyCapturePolicy.evaluate(null, 0L, defaultProperties) shouldBe null
+            }
+
+            test("allows empty payload with a disallowed content type") {
+                BodyCapturePolicy.evaluate("application/octet-stream", 0L, defaultProperties) shouldBe null
             }
         }
 

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestDataExtractorSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestDataExtractorSpec.kt
@@ -140,7 +140,7 @@ class TomcatRequestDataExtractorSpec :
         }
 
         context("extractContent — form data normal path") {
-            test("returns URL-encoded form data when buffer is absent") {
+            test("returns URL-encoded form data when buffer is absent and form capture is allowed") {
                 val request = mockk<Request>(relaxed = true)
                 every { request.getAttribute(LB_INPUT_BUFFER) } returns null
                 every { request.contentType } returns "application/x-www-form-urlencoded"
@@ -148,9 +148,27 @@ class TomcatRequestDataExtractorSpec :
                 every { request.characterEncoding } returns null
                 every { request.parameterMap } returns mapOf("key" to arrayOf("value"))
 
-                val content = TomcatRequestDataExtractor.extractContent(request, defaultProperties)
+                val formAllowed =
+                    defaultProperties.copy(
+                        allowedContentTypes = listOf("application/x-www-form-urlencoded"),
+                    )
+
+                val content = TomcatRequestDataExtractor.extractContent(request, formAllowed)
 
                 content shouldBe "key=value"
+            }
+
+            test("suppresses form data with default allowed content types") {
+                val request = mockk<Request>(relaxed = true)
+                every { request.getAttribute(LB_INPUT_BUFFER) } returns null
+                every { request.contentType } returns "application/x-www-form-urlencoded"
+                every { request.method } returns "POST"
+                every { request.characterEncoding } returns null
+                every { request.parameterMap } returns mapOf("username" to arrayOf("admin"), "password" to arrayOf("secret"))
+
+                val content = TomcatRequestDataExtractor.extractContent(request, defaultProperties)
+
+                content shouldBe "[BINARY CONTENT SUPPRESSED]"
             }
         }
 


### PR DESCRIPTION
## Summary

Two gaps let TeeFilter capture sensitive request bodies with default settings:

1. `DEFAULT_ALLOWED_CONTENT_TYPES` included `application/x-www-form-urlencoded` — exactly the content type Spring Security's `formLogin()` uses to POST `username`/`password`. An operator who enabled TeeFilter (e.g. to log JSON API bodies) and used `%requestContent` captured plaintext credentials from every login attempt. This contradicted the extractor's own documented rationale ("prevent unintended exposure of form data (e.g. login credentials)"), which only held while TeeFilter was off.
2. Payloads without a `Content-Type` header bypassed the allowlist entirely (`?: true`), so unclassifiable bodies were always captured.

## Changes

- Remove `application/x-www-form-urlencoded` from the default allowlist. Form bodies now render as `[BINARY CONTENT SUPPRESSED]` unless the type is explicitly added to `logback.access.tee-filter.allowed-content-types` (override mode already supported this).
- Suppress non-empty payloads that carry no `Content-Type`; empty payloads are always allowed (nothing to expose, and no sentinel noise for body-less requests).
- Update `BodyCapturePolicySpec` / `TomcatRequestDataExtractorSpec` and document the new defaults in the advanced guide (en/ja), README, and SECURITY.md.

## Behavior change

Deployments that relied on the implicit default to capture form bodies must now opt in:

```yaml
logback:
  access:
    tee-filter:
      allowed-content-types:
        - "application/x-www-form-urlencoded"
```

## Testing

- TDD: new/updated policy tests fail before the change and pass after.
- `./gradlew clean build` passes (all module tests including tomcat-mvc TeeFilter integration tests).
- `npm run docs:build` passes; en/ja heading structure verified identical.