### PR TITLE
ci: validate gradle wrapper and scope workflow permissions to jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,10 +8,9 @@ on:
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
+# Least privilege for all jobs; the deploy job declares the write scopes it needs.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -20,6 +19,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # configure-pages reads the Pages site configuration.
+      pages: read
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -55,6 +58,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,9 @@ on:
         type: boolean
         default: true
 
+# Least privilege for all jobs; the release job declares the write scopes it needs.
 permissions:
-  contents: write
-  id-token: write
-  attestations: write
+  contents: read
 
 # Never run two releases concurrently, but do not cancel an in-flight release.
 concurrency:
@@ -156,6 +155,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+
       - name: Set up JDK
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
@@ -197,6 +199,11 @@ jobs:
     needs: [validate, build-and-dry-run]
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    # The only job that uploads attestations; the tag push and release creation use the app token.
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     if: ${{ !inputs.dry-run }}
     environment:
       name: maven-central
@@ -217,6 +224,9 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
 
       - name: Set up JDK
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
+
       - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:


### PR DESCRIPTION
## Summary

Two CI hardening gaps from the project-wide review:

1. **No Gradle wrapper checksum validation.** `test.yml` (which runs on `pull_request`, including fork PRs) and `release.yml` executed `./gradlew` with whatever `gradle-wrapper.jar` the checked-out ref contained. A tampered wrapper jar in a PR would run unnoticed.
2. **Over-privileged workflow-level `permissions`.** `release.yml` gave `contents: write` / `id-token: write` / `attestations: write` to every job including `validate` and `build-and-dry-run`, which only build and inspect. `docs.yml` gave `pages: write` / `id-token: write` to the `build` job that runs `npm ci` on third-party packages.

## Changes

- Add `gradle/actions/wrapper-validation@3f131e8 # v6` (the same SHA-pinned release already used by `dependency-submission.yml`) as the first step after checkout in `test.yml` and in both Gradle-running jobs of `release.yml`. `dependency-submission.yml` needs no change: `gradle/actions` v6 performs wrapper validation by default ([docs](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation)). `codeql.yml` uses `build-mode: none` and never executes the wrapper.
- `release.yml`: workflow-level `permissions: contents: read`; the `release` job declares `contents: read` + `id-token: write` + `attestations: write`. The tag push and GitHub Release creation already use the GitHub App token from `create-github-app-token`, not `GITHUB_TOKEN`, so `contents: write` is not needed anywhere.
- `docs.yml`: workflow-level `permissions: contents: read`; `build` gets `pages: read` (for `configure-pages`), `deploy` gets `pages: write` + `id-token: write`.

## Testing

- All three files parse as valid YAML.
- `test.yml` changes are exercised by this PR's own CI run (the wrapper-validation step must pass for checks to go green).
- `release.yml` / `docs.yml` changes take effect on the next release / docs deploy; both keep the exact same step sequence otherwise.