### PR TITLE
ci: run tests on the JDK selected by the matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           cache: 'gradle'
 
       - name: Build and test
-        run: ./gradlew clean build
+        run: ./gradlew clean build -PtestJavaVersion=${{ matrix.java-version }}
 
       - name: Generate KDoc
         run: ./gradlew dokkaGenerateHtml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,3 +44,19 @@ versionCatalogUpdate {
     // buildSrc-only libraries that the root update task sees as unused are retained via `# @keep`
     // comments in gradle/libs.versions.toml, since the keep {} block only controls versions.
 }
+
+// Every module pins its compile toolchain to Java 21, so without an override the CI
+// matrix would run tests on 21 regardless of the JDK installed on the runner. CI passes
+// -PtestJavaVersion so the compiled artifacts are exercised on each supported runtime.
+val testJavaVersion = providers.gradleProperty("testJavaVersion").map(JavaLanguageVersion::of)
+
+subprojects {
+    plugins.withType<JavaBasePlugin> {
+        val javaToolchains = extensions.getByType<JavaToolchainService>()
+        tasks.withType<Test>().configureEach {
+            javaLauncher = javaToolchains.launcherFor {
+                languageVersion = testJavaVersion.orElse(JavaLanguageVersion.of(21))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The `test.yml` matrix (`java-version: ['21', '25']`) never actually ran tests on JDK 25. Every module pins `java.toolchain.languageVersion = 21`, so the toolchain-aware `test` task always resolved a Java 21 launcher — on the 25 leg, `setup-java` installed JDK 25 for the Gradle daemon while `foojay-resolver` silently provisioned a JDK 21 for test execution. The matrix doubled CI time without adding runtime coverage, contradicting the documented intent ("Build and test on Java 21 and 25").

## Changes

- Root `build.gradle.kts`: a `testJavaVersion` Gradle property overrides the `javaLauncher` of every `Test` task (default remains 21). The compile toolchain stays pinned at 21, so this exercises the artifacts as consumers would run them: compiled for 21, executed on a newer runtime.
- `test.yml`: pass `-PtestJavaVersion=${{ matrix.java-version }}`.

## Verification

- `--info` shows the test executor command switching between `jdk-21.0.9` (default) and `jdk-25.0.2` (`-PtestJavaVersion=25`).
- `./gradlew clean build` and `./gradlew clean build -PtestJavaVersion=25` both pass locally (all modules, exit 0).
- This PR's own CI runs the corrected matrix.