### PR TITLE
fix(tomcat): improve elapsed-time and form-content accuracy

### DIFF
--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSource.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSource.kt
@@ -14,7 +14,8 @@ import java.util.concurrent.TimeUnit
  *
  * @param elapsedTimeNanos the processing time in nanoseconds provided by the Tomcat AccessLog contract.
  *                         Converted to milliseconds before storing.
- *                         Falls back to computing from [Request.getCoyoteRequest] start time when negative.
+ *                         Falls back to computing from [Request.getCoyoteRequest] start time when negative
+ *                         or 0, which the contract defines as "not known".
  */
 internal fun createAccessEventData(
     context: LogbackAccessContext,
@@ -28,7 +29,7 @@ internal fun createAccessEventData(
             timeStamp = System.currentTimeMillis(),
             elapsedTime =
                 elapsedTimeNanos
-                    .takeIf { it >= 0 }
+                    .takeIf { it > 0 }
                     ?.let { TimeUnit.NANOSECONDS.toMillis(it) }
                     ?: (System.currentTimeMillis() - request.coyoteRequest.startTime).coerceAtLeast(0),
             sequenceNumber = context.accessContext.sequenceNumberGenerator?.nextSequenceNumber(),

--- a/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestDataExtractor.kt
+++ b/logback-access-spring-boot-starter/src/main/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestDataExtractor.kt
@@ -6,7 +6,9 @@ import ch.qos.logback.access.common.servlet.Util.isFormUrlEncoded
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties.TeeFilterProperties
 import io.github.seijikohara.spring.boot.logback.access.tee.BodyCapturePolicy
 import org.apache.catalina.connector.Request
+import java.net.URLDecoder.decode
 import java.net.URLEncoder.encode
+import java.nio.charset.Charset
 import java.util.Collections.unmodifiableList
 import java.util.Collections.unmodifiableMap
 
@@ -78,14 +80,47 @@ internal object TomcatRequestDataExtractor {
             ?.let { decodeBufferContent(request, it) ?: decodeFormDataContent(request, it) }
 
     private fun encodeFormDataIfApplicable(request: Request): String? =
-        BodyCapturePolicy.resolveCharset(request.characterEncoding).name().let { charsetName ->
+        BodyCapturePolicy.resolveCharset(request.characterEncoding).let { charset ->
             request
                 .takeIf { isFormUrlEncoded(it) }
-                ?.parameterMap
-                ?.asSequence()
-                ?.flatMap { (key, values) -> values.asSequence().map { key to it } }
+                ?.let { bodyParameterPairs(it, charset) }
                 ?.joinToString("&") { (key, value) ->
-                    "${encode(key, charsetName)}=${encode(value, charsetName)}"
+                    "${encode(key, charset.name())}=${encode(value, charset.name())}"
                 }
+        }
+
+    /**
+     * Rebuilds body parameter pairs from [Request.getParameterMap], which merges query-string
+     * and body parameters with no origin marker. Each pair that also appears in the query
+     * string is removed once so the result reflects only the body; a pair submitted
+     * identically in both places is attributed to the query string, which is already logged
+     * separately.
+     */
+    private fun bodyParameterPairs(
+        request: Request,
+        charset: Charset,
+    ): List<Pair<String, String>> {
+        val queryPairs = parseQueryPairs(request.queryString, charset).toMutableList()
+        return request.parameterMap
+            .asSequence()
+            .flatMap { (key, values) -> values.asSequence().map { key to it } }
+            .filterNot { queryPairs.remove(it) }
+            .toList()
+    }
+
+    // A malformed query string falls back to no subtraction instead of failing the event.
+    private fun parseQueryPairs(
+        queryString: String?,
+        charset: Charset,
+    ): List<Pair<String, String>> =
+        try {
+            queryString
+                ?.split('&')
+                ?.filter { it.isNotEmpty() }
+                ?.map { parameter ->
+                    decode(parameter.substringBefore('='), charset) to decode(parameter.substringAfter('=', ""), charset)
+                }.orEmpty()
+        } catch (_: IllegalArgumentException) {
+            emptyList()
         }
 }

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSourceSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatEventSourceSpec.kt
@@ -70,6 +70,17 @@ class TomcatEventSourceSpec :
             data.elapsedTime.shouldNotBeNull().shouldBeGreaterThanOrEqual(0L)
         }
 
+        test("falls back to the coyote start time when elapsedTimeNanos is 0 (not-known sentinel)") {
+            // The AccessLog contract passes 0 nanoseconds when the duration is not known;
+            // reporting it as a measurement would log an instantaneous response.
+            val request = request()
+            every { request.coyoteRequest.startTime } returns System.currentTimeMillis() - 60_000L
+
+            val data = event(elapsedTimeNanos = 0L, request = request)
+
+            data.elapsedTime.shouldNotBeNull().shouldBeGreaterThanOrEqual(30_000L)
+        }
+
         test("produces a null sequence number when no generator is configured") {
             val data = event(elapsedTimeNanos = 0L, context = context(generator = null))
 

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestDataExtractorSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tomcat/TomcatRequestDataExtractorSpec.kt
@@ -170,6 +170,65 @@ class TomcatRequestDataExtractorSpec :
 
                 content shouldBe "[BINARY CONTENT SUPPRESSED]"
             }
+
+            test("excludes query string parameters from reconstructed form data") {
+                val request = mockk<Request>(relaxed = true)
+                every { request.getAttribute(LB_INPUT_BUFFER) } returns null
+                every { request.contentType } returns "application/x-www-form-urlencoded"
+                every { request.method } returns "POST"
+                every { request.characterEncoding } returns null
+                every { request.queryString } returns "token=abc"
+                every { request.parameterMap } returns
+                    mapOf("token" to arrayOf("abc"), "password" to arrayOf("secret"))
+
+                val formAllowed =
+                    defaultProperties.copy(
+                        allowedContentTypes = listOf("application/x-www-form-urlencoded"),
+                    )
+
+                val content = TomcatRequestDataExtractor.extractContent(request, formAllowed)
+
+                content shouldBe "password=secret"
+            }
+
+            test("keeps the body value when the same name appears in query and body") {
+                val request = mockk<Request>(relaxed = true)
+                every { request.getAttribute(LB_INPUT_BUFFER) } returns null
+                every { request.contentType } returns "application/x-www-form-urlencoded"
+                every { request.method } returns "POST"
+                every { request.characterEncoding } returns null
+                every { request.queryString } returns "key=fromQuery"
+                every { request.parameterMap } returns mapOf("key" to arrayOf("fromQuery", "fromBody"))
+
+                val formAllowed =
+                    defaultProperties.copy(
+                        allowedContentTypes = listOf("application/x-www-form-urlencoded"),
+                    )
+
+                val content = TomcatRequestDataExtractor.extractContent(request, formAllowed)
+
+                content shouldBe "key=fromBody"
+            }
+
+            test("matches percent-encoded query parameters against decoded body parameters") {
+                val request = mockk<Request>(relaxed = true)
+                every { request.getAttribute(LB_INPUT_BUFFER) } returns null
+                every { request.contentType } returns "application/x-www-form-urlencoded"
+                every { request.method } returns "POST"
+                every { request.characterEncoding } returns null
+                every { request.queryString } returns "name=%E3%83%86%E3%82%B9%E3%83%88"
+                every { request.parameterMap } returns
+                    mapOf("name" to arrayOf("テスト"), "body" to arrayOf("1"))
+
+                val formAllowed =
+                    defaultProperties.copy(
+                        allowedContentTypes = listOf("application/x-www-form-urlencoded"),
+                    )
+
+                val content = TomcatRequestDataExtractor.extractContent(request, formAllowed)
+
+                content shouldBe "body=1"
+            }
         }
 
         test("extractContent uses request character encoding for byte array conversion") {


### PR DESCRIPTION
## Summary

Two data-quality issues in the Tomcat extraction path from the project-wide review:

1. **`%D` reported 0 ms when Tomcat does not know the duration.** The Tomcat 11 `AccessLog.log` javadoc defines the `time` parameter as *"Time taken to process the request/response in nanoseconds (use 0 if not known)"*, but `takeIf { it >= 0 }` accepted 0 as a real measurement instead of using the existing start-time fallback.
2. **`%requestContent` attributed query-string values to the form body.** The reconstruction path reads `getParameterMap()`, which merges query and body parameters with no origin marker: `POST /foo?token=abc` with body `password=secret` logged `token=abc&password=secret` as body content.

## Changes

- `TomcatEventSource`: treat `elapsedTimeNanos == 0` as "not known" and fall back to the coyote start-time computation (`takeIf { it > 0 }`).
- `TomcatRequestDataExtractor`: parse the raw query string (decoded with the request charset) and remove each matching pair once from the reconstructed form data. A pair submitted identically in both places is attributed to the query string, which is already logged separately. Malformed query strings fall back to no subtraction rather than dropping the event.

## Testing

- TDD: 4 new tests (0-sentinel fallback; query exclusion; same-name query/body; percent-encoded matching) fail before the fix and pass after.
- `./gradlew clean build` passes.