### PR TITLE
test: close coverage gaps found in the project review

### DIFF
--- a/examples/common/src/main/java/examples/test/common/AbstractSpringPropertyScopeTest.java
+++ b/examples/common/src/main/java/examples/test/common/AbstractSpringPropertyScopeTest.java
@@ -28,7 +28,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *                 defaultValue="default-app" scope="context"/&gt;
  * &lt;springProperty name="customProperty" source="custom.property"
  *                 defaultValue="default-value" scope="context"/&gt;
+ * &lt;springProperty name="missingProperty" source="missing.property"
+ *                 defaultValue="fallback-value" scope="context"/&gt;
  * </pre>
+ * No test sets {@code missing.property}, so {@code missingProperty} must resolve to its default value.
  */
 public abstract class AbstractSpringPropertyScopeTest {
 
@@ -53,11 +56,9 @@ public abstract class AbstractSpringPropertyScopeTest {
 
     @Test
     void contextScopePropertyUsesDefaultWhenSourceMissing() {
-        // Start a new context without setting spring.application.name
-        // This test verifies the existing context has the configured value
-        final var appName = getLogbackAccessContext().getAccessContext().getProperty("appName");
-        assertThat(appName)
-                .as("Property should be set from spring.application.name")
-                .isNotEqualTo("default-app");
+        final var missingProperty = getLogbackAccessContext().getAccessContext().getProperty("missingProperty");
+        assertThat(missingProperty)
+                .as("springProperty must fall back to defaultValue when its source is not set")
+                .isEqualTo("fallback-value");
     }
 }

--- a/examples/common/src/main/java/examples/test/webflux/AbstractReactiveAccessLogTest.java
+++ b/examples/common/src/main/java/examples/test/webflux/AbstractReactiveAccessLogTest.java
@@ -171,4 +171,18 @@ public abstract class AbstractReactiveAccessLogTest {
         final var event = events.get(0);
         assertThat(event.getStatusCode()).isEqualTo(404);
     }
+
+    @Test
+    void remoteUserRendersAsNotAvailableOnReactiveStacks() throws Exception {
+        // Spring Security username capture is Servlet-only, so %u must always render as "-"
+        // on WebFlux regardless of authentication state.
+        final var response = HttpClientTestUtils.get(getBaseUrl() + "/api/hello");
+
+        assertThat(response.statusCode()).isEqualTo(200);
+
+        final var events = AccessEventTestUtils.awaitEvents(listAppender);
+
+        assertThat(events).hasSize(1);
+        assertThat(events.get(0).getRemoteUser()).isEqualTo("-");
+    }
 }

--- a/examples/common/src/main/resources/logback-access-spring-property.xml
+++ b/examples/common/src/main/resources/logback-access-spring-property.xml
@@ -2,6 +2,8 @@
 <configuration>
     <springProperty name="appName" source="spring.application.name" defaultValue="default-app" scope="context"/>
     <springProperty name="customProperty" source="custom.property" defaultValue="default-value" scope="context"/>
+    <!-- No test sets missing.property; exercises the defaultValue fallback. -->
+    <springProperty name="missingProperty" source="missing.property" defaultValue="fallback-value" scope="context"/>
 
     <appender name="list" class="ch.qos.logback.core.read.ListAppender"/>
     <appender-ref ref="list"/>

--- a/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/TeeFilterConfigurationSpec.kt
+++ b/logback-access-spring-boot-starter/src/test/kotlin/io/github/seijikohara/spring/boot/logback/access/tee/TeeFilterConfigurationSpec.kt
@@ -1,0 +1,65 @@
+package io.github.seijikohara.spring.boot.logback.access.tee
+
+import ch.qos.logback.access.common.AccessConstants.TEE_FILTER_EXCLUDES_PARAM
+import ch.qos.logback.access.common.AccessConstants.TEE_FILTER_INCLUDES_PARAM
+import io.github.seijikohara.spring.boot.logback.access.LocalPortStrategy
+import io.github.seijikohara.spring.boot.logback.access.LogbackAccessProperties
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.maps.shouldBeEmpty
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import org.springframework.core.Ordered
+
+class TeeFilterConfigurationSpec :
+    FunSpec({
+        fun properties(
+            includeHosts: String? = null,
+            excludeHosts: String? = null,
+        ): LogbackAccessProperties =
+            LogbackAccessProperties(
+                enabled = true,
+                configLocation = null,
+                localPortStrategy = LocalPortStrategy.SERVER,
+                tomcat = LogbackAccessProperties.TomcatProperties(requestAttributesEnabled = null),
+                teeFilter =
+                    LogbackAccessProperties.TeeFilterProperties(
+                        enabled = true,
+                        includeHosts = includeHosts,
+                        excludeHosts = excludeHosts,
+                        maxPayloadSize = 65536L,
+                        allowedContentTypes = null,
+                    ),
+                filter = LogbackAccessProperties.FilterProperties(null, null),
+            )
+
+        test("registers include and exclude hosts as TeeFilter init parameters") {
+            val registration =
+                TeeFilterConfiguration()
+                    .logbackAccessTeeFilter(properties(includeHosts = "host-a,host-b", excludeHosts = "host-c"))
+
+            registration.initParameters shouldContainExactly
+                mapOf(
+                    TEE_FILTER_INCLUDES_PARAM to "host-a,host-b",
+                    TEE_FILTER_EXCLUDES_PARAM to "host-c",
+                )
+        }
+
+        test("registers no init parameters when hosts are not configured") {
+            val registration = TeeFilterConfiguration().logbackAccessTeeFilter(properties())
+
+            registration.initParameters.shouldBeEmpty()
+        }
+
+        test("ignores blank host lists") {
+            val registration = TeeFilterConfiguration().logbackAccessTeeFilter(properties(includeHosts = " ", excludeHosts = ""))
+
+            registration.initParameters.shouldBeEmpty()
+        }
+
+        test("applies near-highest precedence and a catch-all URL pattern") {
+            val registration = TeeFilterConfiguration().logbackAccessTeeFilter(properties())
+
+            registration.order shouldBe Ordered.HIGHEST_PRECEDENCE + 10
+            registration.urlPatterns shouldBe setOf("/*")
+        }
+    })


### PR DESCRIPTION
## Summary

Three test-coverage gaps from the project-wide review, no production code changes:

1. **TeeFilter host-filtering wiring was untested.** `include-hosts` / `exclude-hosts` are SECURITY.md-documented controls, but nothing verified that `TeeFilterConfiguration` actually places them into the `FilterRegistrationBean` init parameters — a swapped constant or typo would have silently disabled the control. New `TeeFilterConfigurationSpec` locks the wiring, the blank-value handling, the filter order, and the URL pattern.
2. **The WebFlux `%u == "-"` contract had no end-to-end assertion.** `examples/README.md` documents that Spring Security username capture is Servlet-only; a new test in `AbstractReactiveAccessLogTest` asserts it on both jetty-webflux and tomcat-webflux.
3. **`contextScopePropertyUsesDefaultWhenSourceMissing` did not test its name.** Its body re-asserted the configured-value case (already covered by another test). The shared `logback-access-spring-property.xml` now defines a `missingProperty` entry whose source no test sets, and the test asserts the `defaultValue` fallback — verified red (property absent from XML) → green (entry added) across all four example modules.

## Testing

- `./gradlew clean build` passes (all module unit tests + all four example integration suites).