### PR TITLE
build: fix SBOM scope, publishing metadata, and Gradle 10 deprecations

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -18,7 +18,7 @@ paths:
 ### Starter module (`logback-access-spring-boot-starter`)
 
 - Depends on the core module via `api(project(":logback-access-spring-boot-starter-core"))`.
-- Treats server libraries (Tomcat, Jetty, Spring WebMVC, Spring WebFlux, Spring Security) as `compileOnly` dependencies; runtime presence is detected with `@ConditionalOnClass`.
+- Treats server libraries (Tomcat, Jetty, Spring Security) as `compileOnly` dependencies; runtime presence is detected with `@ConditionalOnClass`, and the Servlet/reactive split with `@ConditionalOnWebApplication`.
 - Auto-configuration entry point: `LogbackAccessAutoConfiguration`. Per-server integrations are imported via `@Import`.
 
 ## Conditional Configuration Pattern

--- a/.claude/rules/dependencies.md
+++ b/.claude/rules/dependencies.md
@@ -25,7 +25,7 @@ paths:
 |-------|---------|
 | `api` | The core module (`api(project(":logback-access-spring-boot-starter-core"))`) and the Spring Boot platform BOM. |
 | `implementation` | Required runtime dependencies (e.g., `spring-boot-starter`, `kotlin-logging`). |
-| `compileOnly` | Optional server/framework dependencies (Tomcat, Jetty, Spring WebMVC, Spring WebFlux, Spring Security). |
+| `compileOnly` | Optional server/framework dependencies (Tomcat, Jetty, Spring Security). |
 | `testImplementation` | Full implementations of the `compileOnly` dependencies, plus Kotest, MockK, etc. |
 
 The `compileOnly` scope is critical: it lets the starter compile against multiple optional servers without dragging them onto user classpaths.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,8 +248,20 @@ jobs:
       - name: Build with release version
         run: ./gradlew clean build
 
+      # One invocation per module: a combined graph fails because the plugin cannot create
+      # its configuration on a project whose variants were already observed by a consumer
+      # (core is consumed by starter).
       - name: Generate SBOM
-        run: ./gradlew cyclonedxBom
+        run: |
+          ./gradlew :logback-access-spring-boot-starter-core:cyclonedxBom
+          ./gradlew :logback-access-spring-boot-starter:cyclonedxBom
+
+      # The per-module reports share the file name bom.json; rename them so both can be
+      # attached to the release as distinct assets.
+      - name: Collect SBOMs
+        run: |
+          cp logback-access-spring-boot-starter-core/build/reports/cyclonedx/bom.json logback-access-spring-boot-starter-core.cdx.json
+          cp logback-access-spring-boot-starter/build/reports/cyclonedx/bom.json logback-access-spring-boot-starter.cdx.json
 
       - name: Publish to Maven Central
         run: ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
@@ -280,7 +292,9 @@ jobs:
           draft: false
           prerelease: false
           token: ${{ steps.generate_token.outputs.token }}
-          files: build/reports/cyclonedx/bom.json
+          files: |
+            logback-access-spring-boot-starter-core.cdx.json
+            logback-access-spring-boot-starter.cdx.json
 
       - name: Release summary
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.axion.release)
     alias(libs.plugins.binary.compatibility.validator)
-    alias(libs.plugins.cyclonedx)
     alias(libs.plugins.version.catalog.update)
 }
 

--- a/buildSrc/src/main/kotlin/maven-publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/maven-publish-conventions.gradle.kts
@@ -35,7 +35,7 @@ mavenPublishing {
             }
         }
         scm {
-            connection = "scm:git:git://github.com/seijikohara/logback-access-spring-boot-starter.git"
+            connection = "scm:git:https://github.com/seijikohara/logback-access-spring-boot-starter.git"
             developerConnection = "scm:git:ssh://github.com/seijikohara/logback-access-spring-boot-starter.git"
             url = "https://github.com/seijikohara/logback-access-spring-boot-starter"
         }

--- a/examples/jetty-mvc/build.gradle.kts
+++ b/examples/jetty-mvc/build.gradle.kts
@@ -44,7 +44,7 @@ tasks.named<Jar>("jar") {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        named<JvmTestSuite>("test") {
             useJUnitJupiter()
             dependencies {
                 implementation(project(":examples:common"))

--- a/examples/jetty-webflux/build.gradle.kts
+++ b/examples/jetty-webflux/build.gradle.kts
@@ -43,7 +43,7 @@ tasks.named<Jar>("jar") {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        named<JvmTestSuite>("test") {
             useJUnitJupiter()
             dependencies {
                 implementation(project(":examples:common"))

--- a/examples/tomcat-mvc/build.gradle.kts
+++ b/examples/tomcat-mvc/build.gradle.kts
@@ -39,7 +39,7 @@ tasks.named<Jar>("jar") {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        named<JvmTestSuite>("test") {
             useJUnitJupiter()
             dependencies {
                 implementation(project(":examples:common"))

--- a/examples/tomcat-webflux/build.gradle.kts
+++ b/examples/tomcat-webflux/build.gradle.kts
@@ -43,7 +43,7 @@ tasks.named<Jar>("jar") {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        named<JvmTestSuite>("test") {
             useJUnitJupiter()
             dependencies {
                 implementation(project(":examples:common"))

--- a/logback-access-spring-boot-starter-core/build.gradle.kts
+++ b/logback-access-spring-boot-starter-core/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
     id("maven-publish-conventions")
     id("org.jetbrains.kotlin.kapt")
+    // Applied per published module (not at the root) so the SBOM reflects only the
+    // released artifact's dependencies, not the example apps' test dependencies.
+    alias(libs.plugins.cyclonedx)
     alias(libs.plugins.detekt)
     alias(libs.plugins.spotless)
     `java-library`
@@ -44,6 +47,13 @@ java {
     }
 }
 
+// The SBOM describes what a consumer of the published artifact pulls in, so restrict it
+// to the runtime dependency graph; the default includes test configurations. The
+// aggregate cyclonedxBom task builds on this task's output.
+tasks.cyclonedxDirectBom {
+    includeConfigs = listOf("runtimeClasspath")
+}
+
 tasks.jar {
     manifest {
         attributes("Automatic-Module-Name" to "io.github.seijikohara.logback.access.core")
@@ -61,7 +71,7 @@ spotless {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        named<JvmTestSuite>("test") {
             useJUnitJupiter()
             dependencies {
                 implementation(platform(libs.kotest.bom))

--- a/logback-access-spring-boot-starter/build.gradle.kts
+++ b/logback-access-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,8 @@
 plugins {
     id("maven-publish-conventions")
+    // Applied per published module (not at the root) so the SBOM reflects only the
+    // released artifact's dependencies, not the example apps' test dependencies.
+    alias(libs.plugins.cyclonedx)
     alias(libs.plugins.detekt)
     alias(libs.plugins.spotless)
     `java-library`
@@ -22,8 +25,6 @@ dependencies {
     implementation(libs.spring.boot.starter)
     implementation(libs.kotlin.logging)
 
-    compileOnly(libs.spring.boot.starter.webmvc)
-    compileOnly(libs.spring.boot.starter.webflux)
     compileOnly(libs.spring.boot.starter.tomcat)
     compileOnly(libs.spring.boot.starter.jetty)
     compileOnly(libs.spring.boot.starter.security)
@@ -33,6 +34,13 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
+}
+
+// The SBOM describes what a consumer of the published artifact pulls in, so restrict it
+// to the runtime dependency graph; the default includes test configurations. The
+// aggregate cyclonedxBom task builds on this task's output.
+tasks.cyclonedxDirectBom {
+    includeConfigs = listOf("runtimeClasspath")
 }
 
 tasks.jar {
@@ -52,7 +60,7 @@ spotless {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        named<JvmTestSuite>("test") {
             useJUnitJupiter()
             dependencies {
                 implementation(platform(libs.kotest.bom))


### PR DESCRIPTION
## Summary

Four build hygiene items from the project-wide review:

1. **SBOM covered the wrong scope (#10).** The CycloneDX plugin at the root aggregated all seven modules, so the release-attached `bom.json` contained the example apps' test dependencies (`junit-jupiter`, `assertj-core`, `spring-boot-starter-test`, both Tomcat and Jetty) — verified by inspecting the generated file. The plugin now applies to the two published modules with `includeConfigs = ["runtimeClasspath"]`, and the release attaches one `.cdx.json` per artifact. Verified: regenerated SBOMs contain 0 test-scope components and the expected runtime graph.
2. **POM `scm.connection` used `git://`**, disabled by GitHub in 2022 → `https`.
3. **Unused `compileOnly` webmvc/webflux starters removed (#15).** No starter source references WebMVC/WebFlux types — verified by compiling without them. `rules/architecture.md` / `rules/dependencies.md` updated to match (the Servlet/reactive split is detected via `@ConditionalOnWebApplication`).
4. **Gradle 10 deprecation warnings eliminated (#14).** The source was our own build scripts: `val test by getting(JvmTestSuite::class)` in six files. Replaced with `named<JvmTestSuite>("test")`; `./gradlew help --warning-mode all` now reports zero deprecations.

## Notes

- `./gradlew cyclonedxBom` must run per module in separate invocations; a combined graph fails because the plugin cannot create its consumable configuration on a project whose variants were already observed by a consumer (core ← starter, previously examples/common ← example apps). The release workflow does this and the step comment documents it.
- No consumer-facing dependency changes: `compileOnly` never reached the published POM.

## Testing

- `./gradlew clean build` passes.
- `./gradlew help --warning-mode all`: 0 deprecation warnings (was 6 occurrences).
- Both module SBOMs regenerate successfully and were content-checked.