### PR TITLE
refactor(examples): align jetty-webflux exclusion and jetty-mvc test names

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -38,7 +38,7 @@ Prefer behavioral test names (`"returns ..."`, `"throws ... when ..."`) over gen
 - **Framework**: JUnit 5 with AssertJ assertions.
 - **Pattern**: `@SpringBootTest(webEnvironment = RANDOM_PORT)` against a real embedded server, plus the project's `HttpClientTestUtils` to issue requests.
 - **Coverage matrix**: four runnable apps — `tomcat-mvc`, `tomcat-webflux`, `jetty-mvc`, `jetty-webflux` — exercise the cross product of server (Tomcat / Jetty) and stack (Servlet MVC / reactive WebFlux).
-- **TeeFilter tests** are Tomcat-only. The Jetty equivalent (`JettyTeeFilterTest`) is annotated `@Disabled` because Jetty 12's `RequestLog` API runs below the Servlet layer and cannot see attributes that TeeFilter writes to the Servlet request.
+- **TeeFilter tests** are Tomcat-only. The Jetty equivalent (`TeeFilterTest` in `jetty-mvc`) is annotated `@Disabled` because Jetty 12's `RequestLog` API runs below the Servlet layer and cannot see attributes that TeeFilter writes to the Servlet request.
 - **Shared utilities** (`HttpClientTestUtils`, `AccessEventTestUtils`, abstract base classes) live in `examples/common`.
 
 ## Running Tests

--- a/examples/README.md
+++ b/examples/README.md
@@ -111,7 +111,7 @@ classDiagram
     }
 
     BasicAccessLogTest --|> AbstractBasicAccessLogTest
-    JettyBasicAccessLogTest --|> AbstractBasicAccessLogTest
+    BasicAccessLogTest --|> AbstractBasicAccessLogTest
     SecurityIntegrationTest --|> AbstractSecurityTest
     ReactiveAccessLogTest --|> AbstractReactiveAccessLogTest
 ```
@@ -213,7 +213,7 @@ sequenceDiagram
     RL->>RL: Cannot read Servlet attributes
 ```
 
-The `JettyTeeFilterTest` class in `jetty-mvc` is annotated `@Disabled` to make this limitation explicit.
+The `TeeFilterTest` class in `jetty-mvc` is annotated `@Disabled` to make this limitation explicit.
 
 ## Test Classes by Module
 
@@ -237,15 +237,15 @@ Each example app composes the abstract base classes from `common` to cover the f
 
 | Test Class | Coverage |
 |------------|----------|
-| `JettyBasicAccessLogTest` | Access log emission for the standard HTTP methods. |
-| `JettySecurityTest` | Spring Security `%u` capture. |
-| `JettyTeeFilterTest` | `@Disabled` — TeeFilter is not supported on Jetty 12 (see [Jetty Limitations](#jetty-limitations)). |
-| `JettyLocalPortStrategyTest` | `local-port-strategy` resolution. |
-| `JettyUrlFilteringTest` | URL pattern filtering. |
-| `JettyJsonLoggingTest` | JSON output via `LogstashAccessEncoder`. |
-| `JettySpringProfileTest` | Profile-specific appenders. |
-| `JettySpringPropertyScopeTest` | `<springProperty>` scopes. |
-| `JettyDisabledAccessLogTest` | `logback.access.enabled=false` disables auto-configuration. |
+| `BasicAccessLogTest` | Access log emission for the standard HTTP methods. |
+| `SecurityIntegrationTest` | Spring Security `%u` capture. |
+| `TeeFilterTest` | `@Disabled` — TeeFilter is not supported on Jetty 12 (see [Jetty Limitations](#jetty-limitations)). |
+| `LocalPortStrategyTest` | `local-port-strategy` resolution. |
+| `UrlFilteringTest` | URL pattern filtering. |
+| `JsonLoggingTest` | JSON output via `LogstashAccessEncoder`. |
+| `SpringProfileTest` | Profile-specific appenders. |
+| `SpringPropertyScopeTest` | `<springProperty>` scopes. |
+| `DisabledAccessLogTest` | `logback.access.enabled=false` disables auto-configuration. |
 
 ### Tomcat WebFlux
 

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/BasicAccessLogTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/BasicAccessLogTest.java
@@ -1,6 +1,6 @@
 package examples.jettymvc;
 
-import examples.test.mvc.AbstractLocalPortStrategyTest;
+import examples.AbstractBasicAccessLogTest;
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -8,17 +8,11 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 /**
- * Tests the localPortStrategy=LOCAL configuration on Jetty.
- * <p>
- * When LOCAL strategy is used, the access event captures the actual
- * local port that received the connection, rather than the server port
- * from the Host header or X-Forwarded-Port.
+ * Basic access log tests for Jetty + MVC.
+ * Extends AbstractBasicAccessLogTest for common HTTP method tests.
  */
-@SpringBootTest(
-        webEnvironment = WebEnvironment.RANDOM_PORT,
-        properties = "logback.access.local-port-strategy=LOCAL"
-)
-class JettyLocalPortStrategyTest extends AbstractLocalPortStrategyTest {
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class BasicAccessLogTest extends AbstractBasicAccessLogTest {
 
     @Autowired
     LogbackAccessContext logbackAccessContext;
@@ -34,10 +28,5 @@ class JettyLocalPortStrategyTest extends AbstractLocalPortStrategyTest {
     @Override
     protected String getBaseUrl() {
         return "http://localhost:" + port;
-    }
-
-    @Override
-    protected int getPort() {
-        return port;
     }
 }

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/DisabledAccessLogTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/DisabledAccessLogTest.java
@@ -14,7 +14,7 @@ import org.springframework.context.ApplicationContext;
         webEnvironment = WebEnvironment.RANDOM_PORT,
         properties = "logback.access.enabled=false"
 )
-class JettyDisabledAccessLogTest extends AbstractDisabledAccessLogTest {
+class DisabledAccessLogTest extends AbstractDisabledAccessLogTest {
 
     @Autowired
     ApplicationContext applicationContext;

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/JsonLoggingTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/JsonLoggingTest.java
@@ -1,6 +1,6 @@
 package examples.jettymvc;
 
-import examples.test.common.AbstractMalformedRequestAccessLogTest;
+import examples.test.common.AbstractJsonLoggingTest;
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -8,11 +8,14 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 /**
- * Malformed request access log tests for Jetty + MVC.
- * Jetty synthesizes a "BAD /badMessage HTTP/1.0" placeholder request for unparseable requests.
+ * Tests for JSON logging with LogstashAccessEncoder on Jetty.
+ * Verifies that access events are correctly captured and can be encoded as JSON.
  */
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-class JettyMalformedRequestAccessLogTest extends AbstractMalformedRequestAccessLogTest {
+@SpringBootTest(
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = "logback.access.config-location=classpath:logback-access-json.xml"
+)
+class JsonLoggingTest extends AbstractJsonLoggingTest {
 
     @Autowired
     LogbackAccessContext logbackAccessContext;
@@ -26,12 +29,7 @@ class JettyMalformedRequestAccessLogTest extends AbstractMalformedRequestAccessL
     }
 
     @Override
-    protected int getPort() {
-        return port;
-    }
-
-    @Override
-    protected String getExpectedMalformedMethod() {
-        return "BAD";
+    protected String getBaseUrl() {
+        return "http://localhost:" + port;
     }
 }

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/LocalPortStrategyTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/LocalPortStrategyTest.java
@@ -1,6 +1,6 @@
 package examples.jettymvc;
 
-import examples.AbstractSecurityTest;
+import examples.test.mvc.AbstractLocalPortStrategyTest;
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -8,11 +8,17 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 /**
- * Tests for Spring Security integration with Jetty access logging.
- * Extends AbstractSecurityTest for common security tests.
+ * Tests the localPortStrategy=LOCAL configuration on Jetty.
+ * <p>
+ * When LOCAL strategy is used, the access event captures the actual
+ * local port that received the connection, rather than the server port
+ * from the Host header or X-Forwarded-Port.
  */
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-class JettySecurityTest extends AbstractSecurityTest {
+@SpringBootTest(
+        webEnvironment = WebEnvironment.RANDOM_PORT,
+        properties = "logback.access.local-port-strategy=LOCAL"
+)
+class LocalPortStrategyTest extends AbstractLocalPortStrategyTest {
 
     @Autowired
     LogbackAccessContext logbackAccessContext;
@@ -31,12 +37,7 @@ class JettySecurityTest extends AbstractSecurityTest {
     }
 
     @Override
-    protected String getAuthenticatedUsername() {
-        return "user";
-    }
-
-    @Override
-    protected String getAuthenticatedPassword() {
-        return "password";
+    protected int getPort() {
+        return port;
     }
 }

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/MalformedRequestAccessLogTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/MalformedRequestAccessLogTest.java
@@ -1,6 +1,6 @@
 package examples.jettymvc;
 
-import examples.test.common.AbstractJsonLoggingTest;
+import examples.test.common.AbstractMalformedRequestAccessLogTest;
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -8,14 +8,11 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 /**
- * Tests for JSON logging with LogstashAccessEncoder on Jetty.
- * Verifies that access events are correctly captured and can be encoded as JSON.
+ * Malformed request access log tests for Jetty + MVC.
+ * Jetty synthesizes a "BAD /badMessage HTTP/1.0" placeholder request for unparseable requests.
  */
-@SpringBootTest(
-        webEnvironment = WebEnvironment.RANDOM_PORT,
-        properties = "logback.access.config-location=classpath:logback-access-json.xml"
-)
-class JettyJsonLoggingTest extends AbstractJsonLoggingTest {
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class MalformedRequestAccessLogTest extends AbstractMalformedRequestAccessLogTest {
 
     @Autowired
     LogbackAccessContext logbackAccessContext;
@@ -29,7 +26,12 @@ class JettyJsonLoggingTest extends AbstractJsonLoggingTest {
     }
 
     @Override
-    protected String getBaseUrl() {
-        return "http://localhost:" + port;
+    protected int getPort() {
+        return port;
+    }
+
+    @Override
+    protected String getExpectedMalformedMethod() {
+        return "BAD";
     }
 }

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/SecurityIntegrationTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/SecurityIntegrationTest.java
@@ -1,6 +1,6 @@
 package examples.jettymvc;
 
-import examples.AbstractBasicAccessLogTest;
+import examples.AbstractSecurityTest;
 import io.github.seijikohara.spring.boot.logback.access.LogbackAccessContext;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -8,11 +8,11 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
 /**
- * Basic access log tests for Jetty + MVC.
- * Extends AbstractBasicAccessLogTest for common HTTP method tests.
+ * Tests for Spring Security integration with Jetty access logging.
+ * Extends AbstractSecurityTest for common security tests.
  */
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-class JettyBasicAccessLogTest extends AbstractBasicAccessLogTest {
+class SecurityIntegrationTest extends AbstractSecurityTest {
 
     @Autowired
     LogbackAccessContext logbackAccessContext;
@@ -28,5 +28,15 @@ class JettyBasicAccessLogTest extends AbstractBasicAccessLogTest {
     @Override
     protected String getBaseUrl() {
         return "http://localhost:" + port;
+    }
+
+    @Override
+    protected String getAuthenticatedUsername() {
+        return "user";
+    }
+
+    @Override
+    protected String getAuthenticatedPassword() {
+        return "password";
     }
 }

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/SpringProfileTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/SpringProfileTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for Spring Profile integration with logback-access configuration on Jetty.
  * Uses logback-access-spring-profile.xml which defines profile-specific appenders.
  */
-class JettySpringProfileTest {
+class SpringProfileTest {
 
     @Nested
     @SpringBootTest(

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/SpringPropertyScopeTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/SpringPropertyScopeTest.java
@@ -18,7 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
                 "custom.property=custom-test-value"
         }
 )
-class JettySpringPropertyScopeTest extends AbstractSpringPropertyScopeTest {
+class SpringPropertyScopeTest extends AbstractSpringPropertyScopeTest {
 
     @Autowired
     LogbackAccessContext logbackAccessContext;

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/TeeFilterTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/TeeFilterTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("teefilter")
 @Disabled("TeeFilter does not work on Jetty 12 - RequestLog API cannot access Servlet request attributes")
-class JettyTeeFilterTest extends AbstractTeeFilterTest {
+class TeeFilterTest extends AbstractTeeFilterTest {
 
     @Autowired
     LogbackAccessContext logbackAccessContext;

--- a/examples/jetty-mvc/src/test/java/examples/jettymvc/UrlFilteringTest.java
+++ b/examples/jetty-mvc/src/test/java/examples/jettymvc/UrlFilteringTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Tests for URL pattern filtering configuration on Jetty.
  */
-class JettyUrlFilteringTest {
+class UrlFilteringTest {
 
     /**
      * Tests exclude pattern filtering on Jetty.

--- a/examples/jetty-webflux/build.gradle.kts
+++ b/examples/jetty-webflux/build.gradle.kts
@@ -20,7 +20,7 @@ nullaway {
 }
 
 configurations.all {
-    exclude(group = "org.springframework.boot", module = "spring-boot-starter-tomcat")
+    exclude(group = "org.springframework.boot", module = "spring-boot-starter-reactor-netty")
 }
 
 dependencies {


### PR DESCRIPTION
## Summary

Two example-module consistency items from the project-wide review:

1. **jetty-webflux excluded the wrong starter.** Its `configurations.all` block excluded `spring-boot-starter-tomcat` — which `spring-boot-starter-webflux` never pulls — instead of `spring-boot-starter-reactor-netty`, which it does. The example worked only because Spring Boot's reactive server auto-configuration happened to select Jetty over Netty. Exclude Netty explicitly (mirroring `tomcat-webflux`) so the example stops depending on auto-configuration ordering. Verified: `reactor-netty` no longer appears on the module's test runtime classpath and all tests still pass on Jetty.
2. **jetty-mvc test naming.** It was the only module prefixing test classes with the server name (`JettyBasicAccessLogTest` vs `BasicAccessLogTest` in the other three modules). Renamed all ten classes to the shared names (`JettySecurityTest` → `SecurityIntegrationTest` mirrors tomcat-mvc); packages already disambiguate. References in `examples/README.md` and `.claude/rules/testing.md` updated.

## Testing

- `./gradlew clean build` passes (all four example suites, including every renamed class).
- `:examples:jetty-webflux:dependencies` confirms no `reactor-netty` on the test runtime classpath.